### PR TITLE
update workflow displays to show the difference in worktrees and branches better

### DIFF
--- a/src/tui/WorktreeList.test.tsx
+++ b/src/tui/WorktreeList.test.tsx
@@ -47,8 +47,34 @@ describe("WorktreeList", () => {
       makeWorktree({ branch: "feature-auth", isMain: false }),
     ];
     const { lastFrame } = renderList(worktrees);
+    expect(lastFrame()).toContain("primary");
     expect(lastFrame()).toContain("main");
     expect(lastFrame()).toContain("feature-auth");
+  });
+
+  test('shows "primary" label for main worktree', () => {
+    const wt = makeWorktree({ isMain: true, branch: "some-branch" });
+    const { lastFrame } = renderList([wt]);
+    expect(lastFrame()).toContain("primary");
+    expect(lastFrame()).toContain("some-branch");
+  });
+
+  test("shows branch name as subtitle for main worktree, not as main label", () => {
+    const wt = makeWorktree({ isMain: true, branch: "my-feature-branch" });
+    const { lastFrame } = renderList([wt]);
+    const frame = lastFrame()!;
+    const lines = frame.split("\n");
+    const primaryLine = lines.find((l) => l.includes("primary"));
+    expect(primaryLine).not.toContain("my-feature-branch");
+    const subtitleLine = lines.find((l) => l.includes("my-feature-branch"));
+    expect(subtitleLine).toBeDefined();
+  });
+
+  test("non-main worktrees show branch name as main label, not primary", () => {
+    const wt = makeWorktree({ isMain: false, branch: "feature-x" });
+    const { lastFrame } = renderList([wt]);
+    expect(lastFrame()).toContain("feature-x");
+    expect(lastFrame()).not.toContain("primary");
   });
 
   test("selected item shows ▶ prefix", () => {
@@ -128,7 +154,7 @@ describe("WorktreeList", () => {
 
   test("truncates long branch names to fit width", () => {
     const longBranch = "a".repeat(50);
-    const wt = makeWorktree({ branch: longBranch });
+    const wt = makeWorktree({ branch: longBranch, isMain: false });
     const { lastFrame } = renderList([wt], 0, 30);
     expect(lastFrame()).toContain("…");
   });

--- a/src/tui/WorktreeList.tsx
+++ b/src/tui/WorktreeList.tsx
@@ -24,14 +24,15 @@ interface WorktreeRowProps {
 
 function WorktreeRow({ worktree, isSelected, width }: WorktreeRowProps) {
   const prefix = isSelected ? "▶ " : "  ";
-  const branchColor = worktree.isMain ? "blue" : "white";
 
-  // Truncate branch name to fit
-  const maxBranchLen = width - 18;
-  const branch =
-    worktree.branch.length > maxBranchLen
-      ? worktree.branch.slice(0, maxBranchLen - 1) + "…"
-      : worktree.branch.padEnd(maxBranchLen);
+  const displayName = worktree.isMain ? "primary" : worktree.branch;
+  const displayColor = worktree.isMain ? "green" : "white";
+
+  const maxNameLen = width - 18;
+  const name =
+    displayName.length > maxNameLen
+      ? displayName.slice(0, maxNameLen - 1) + "…"
+      : displayName.padEnd(maxNameLen);
 
   return (
     <Box flexDirection="column">
@@ -39,13 +40,19 @@ function WorktreeRow({ worktree, isSelected, width }: WorktreeRowProps) {
         <Text bold={isSelected} color={isSelected ? "cyan" : undefined}>
           {prefix}
         </Text>
-        <Text color={branchColor} bold={isSelected}>
-          {branch}
+        <Text color={displayColor} bold={isSelected}>
+          {name}
         </Text>
         <Text> </Text>
         <PRLabel worktree={worktree} />
         <ChangesLabel worktree={worktree} />
       </Box>
+      {worktree.isMain && (
+        <Text color="gray" dimColor>
+          {"     "}
+          {worktree.branch}
+        </Text>
+      )}
       {worktree.baseBranch && !worktree.isMain && (
         <Text color="gray" dimColor>
           {"     "}off {worktree.baseBranch}


### PR DESCRIPTION
This pull request updates the `WorktreeList` component and its tests to improve how the main worktree is displayed. The main worktree is now labeled as "primary" with special styling, and its branch name is shown as a subtitle. Several new tests ensure this behavior is correct, and the logic for truncating names has been updated to support these changes.

**Display and Labeling Improvements:**

* The main worktree now displays "primary" (in green) as its main label, and its branch name is shown as a gray subtitle underneath. Non-main worktrees continue to display their branch name as the main label. (`src/tui/WorktreeList.tsx`)
* The logic for truncating the displayed name has been updated to handle both "primary" and branch names appropriately. (`src/tui/WorktreeList.tsx`)

**Test Enhancements:**

* Added tests to verify that "primary" is shown for the main worktree, that the branch name appears as a subtitle, and that non-main worktrees show their branch name as the main label. (`src/tui/WorktreeList.test.tsx`)
* Updated the truncation test to explicitly use a non-main worktree, ensuring consistent test behavior. (`src/tui/WorktreeList.test.tsx`)