### PR TITLE
Fix: mark current worktree as active in grove and grove status

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -73,6 +73,7 @@ export function printStatus(worktrees: Worktree[]): void {
       (wt.isMain
         ? chalk.blue(wt.branch) + chalk.gray(" (main)")
         : chalk.white(wt.branch)) +
+      (wt.isCurrent ? chalk.cyan(" ◀ current") : "") +
       (wt.baseBranch && !wt.isMain
         ? "\n" + chalk.gray(`  off ${wt.baseBranch}`)
         : "");

--- a/src/data/worktrees.test.ts
+++ b/src/data/worktrees.test.ts
@@ -213,6 +213,38 @@ describe("loadWorktrees", () => {
     expect(worktrees[0].baseBranch).toBe("main");
   });
 
+  test("sets isCurrent=true when cwd matches the worktree path exactly", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue("/repo/main");
+    const { worktrees } = await loadWorktrees("/repo");
+    expect(worktrees[0].isCurrent).toBe(true);
+    expect(worktrees[1].isCurrent).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  test("sets isCurrent=true when cwd is a subdirectory of the worktree path", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue("/repo/feature/src/components");
+    const { worktrees } = await loadWorktrees("/repo");
+    expect(worktrees[1].isCurrent).toBe(true);
+    expect(worktrees[0].isCurrent).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  test("sets isCurrent=false for all worktrees when cwd is unrelated", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue("/some/other/directory");
+    const { worktrees } = await loadWorktrees("/repo");
+    expect(worktrees.every((wt) => !wt.isCurrent)).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  test("sets isCurrent=false for all worktrees when cwd throws", async () => {
+    vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("no such file or directory");
+    });
+    const { worktrees } = await loadWorktrees("/repo");
+    expect(worktrees.every((wt) => !wt.isCurrent)).toBe(true);
+    vi.restoreAllMocks();
+  });
+
   test("populates changeFootprint when git diff returns output", async () => {
     mockedExeca.mockImplementation(async (cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "worktree") {

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -307,6 +307,8 @@ export async function loadWorktrees(
     fetchPRsByBranch(repoPath),
   ]);
 
+  const cwd = process.cwd();
+
   const worktrees = await Promise.all(
     raw.map(async (wt, idx) => {
       const branch = wt.branch || "(unknown)";
@@ -321,7 +323,7 @@ export async function loadWorktrees(
         branch,
         baseBranch,
         isMain: idx === 0,
-        isCurrent: false,
+        isCurrent: cwd === wt.path || cwd.startsWith(wt.path + path.sep),
         head: wt.head || "",
         docker,
         changeFootprint,

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -307,7 +307,12 @@ export async function loadWorktrees(
     fetchPRsByBranch(repoPath),
   ]);
 
-  const cwd = process.cwd();
+  let cwd = "";
+  try {
+    cwd = process.cwd();
+  } catch {
+    // cwd deleted/moved — no worktree will match, isCurrent stays false
+  }
 
   const worktrees = await Promise.all(
     raw.map(async (wt, idx) => {

--- a/src/tui/WorktreeList.test.tsx
+++ b/src/tui/WorktreeList.test.tsx
@@ -153,7 +153,11 @@ describe("WorktreeList", () => {
   });
 
   test('shows "◀ current" label when isCurrent is true', () => {
-    const wt = makeWorktree({ isCurrent: true, isMain: false, branch: "feature" });
+    const wt = makeWorktree({
+      isCurrent: true,
+      isMain: false,
+      branch: "feature",
+    });
     const { lastFrame } = renderList([wt]);
     expect(lastFrame()).toContain("◀ current");
   });

--- a/src/tui/WorktreeList.test.tsx
+++ b/src/tui/WorktreeList.test.tsx
@@ -152,6 +152,18 @@ describe("WorktreeList", () => {
     expect(lastFrame()).not.toContain("off");
   });
 
+  test('shows "◀ current" label when isCurrent is true', () => {
+    const wt = makeWorktree({ isCurrent: true, isMain: false, branch: "feature" });
+    const { lastFrame } = renderList([wt]);
+    expect(lastFrame()).toContain("◀ current");
+  });
+
+  test('does not show "◀ current" label when isCurrent is false', () => {
+    const wt = makeWorktree({ isCurrent: false });
+    const { lastFrame } = renderList([wt]);
+    expect(lastFrame()).not.toContain("◀ current");
+  });
+
   test("truncates long branch names to fit width", () => {
     const longBranch = "a".repeat(50);
     const wt = makeWorktree({ branch: longBranch, isMain: false });

--- a/src/tui/WorktreeList.tsx
+++ b/src/tui/WorktreeList.tsx
@@ -53,6 +53,11 @@ function WorktreeRow({ worktree, isSelected, width }: WorktreeRowProps) {
           {worktree.branch}
         </Text>
       )}
+      {worktree.isCurrent && (
+        <Text color="cyan" dimColor>
+          {"     "}◀ current
+        </Text>
+      )}
       {worktree.baseBranch && !worktree.isMain && (
         <Text color="gray" dimColor>
           {"     "}off {worktree.baseBranch}


### PR DESCRIPTION
## Summary
- `loadWorktrees` now compares `process.cwd()` against each worktree's path to detect which one the user is inside
- `grove status` shows a `◀ current` marker (in cyan) next to the active worktree's branch name
- The TUI (`grove` with no args) shows the same `◀ current` indicator below the worktree row

## Test plan
- [ ] `cd` into a worktree directory, run `grove status` — the current worktree should show `◀ current`
- [ ] Run from inside a subdirectory of a worktree — should still detect correctly
- [ ] Run from the repo root (main worktree) — main worktree should show `◀ current`
- [ ] Run `grove` (TUI mode) from inside a worktree — the `◀ current` label should appear

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)