### PR TITLE
Fix: fall back to .env.example when .env.worktree is absent

### DIFF
--- a/src/data/worktrees.test.ts
+++ b/src/data/worktrees.test.ts
@@ -11,7 +11,7 @@ vi.mock("fs/promises", () => ({
 
 import { execa } from "execa";
 import { existsSync } from "fs";
-import { mkdir, writeFile } from "fs/promises";
+import { readFile, mkdir, writeFile } from "fs/promises";
 import {
   resolveWorktreeRoot,
   detectRepoRoot,
@@ -22,6 +22,7 @@ import {
 
 const mockedExeca = execa as MockedFunction<typeof execa>;
 const mockedExistsSync = existsSync as MockedFunction<typeof existsSync>;
+const mockedReadFile = readFile as MockedFunction<typeof readFile>;
 const mockedMkdir = mkdir as MockedFunction<typeof mkdir>;
 const mockedWriteFile = writeFile as MockedFunction<typeof writeFile>;
 
@@ -159,6 +160,23 @@ describe("loadWorktrees", () => {
   test("sets docker=null when no .env.worktree exists", async () => {
     const { worktrees } = await loadWorktrees("/repo");
     expect(worktrees[0].docker).toBeNull();
+  });
+
+  test("populates docker from .env.example when .env.worktree is absent", async () => {
+    mockedExistsSync.mockImplementation((p: unknown) => {
+      const s = String(p);
+      return s.endsWith(".env.example") || s.endsWith("docker-compose.yml");
+    });
+    mockedReadFile.mockResolvedValue(
+      "COMPOSE_PROJECT_NAME=myapp\nWEB_PORT=3000\n",
+    );
+
+    const { worktrees } = await loadWorktrees("/repo");
+    const wt = worktrees[0];
+    expect(wt.docker).not.toBeNull();
+    expect(wt.docker?.envSource).toBe("example");
+    expect(wt.docker?.projectName).toBe("myapp");
+    expect(wt.docker?.webPort).toBe(3000);
   });
 
   test("sets baseBranch=null when no upstream is configured", async () => {

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -135,12 +135,14 @@ async function readBaseBranch(
 async function readDockerInfo(worktreePath: string) {
   const envPath = path.join(worktreePath, ".env.worktree");
   const examplePath = path.join(worktreePath, ".env.example");
-  const resolvedEnvPath = existsSync(envPath)
+  const hasWorktreeEnv = existsSync(envPath);
+  const resolvedEnvPath = hasWorktreeEnv
     ? envPath
     : existsSync(examplePath)
       ? examplePath
       : null;
   if (!resolvedEnvPath) return null;
+  const envSource = hasWorktreeEnv ? ("worktree" as const) : ("example" as const);
 
   const hasCompose =
     existsSync(path.join(worktreePath, "docker-compose.yml")) ||
@@ -204,6 +206,7 @@ async function readDockerInfo(worktreePath: string) {
       localstackPort,
       redisDb: env["REDIS_DB"],
       dbSchema: env["DB_SCHEMA"],
+      envSource,
     };
   } catch {
     return {
@@ -213,6 +216,7 @@ async function readDockerInfo(worktreePath: string) {
       localstackPort,
       redisDb: env["REDIS_DB"],
       dbSchema: env["DB_SCHEMA"],
+      envSource,
     };
   }
 }

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -134,7 +134,13 @@ async function readBaseBranch(
 
 async function readDockerInfo(worktreePath: string) {
   const envPath = path.join(worktreePath, ".env.worktree");
-  if (!existsSync(envPath)) return null;
+  const examplePath = path.join(worktreePath, ".env.example");
+  const resolvedEnvPath = existsSync(envPath)
+    ? envPath
+    : existsSync(examplePath)
+      ? examplePath
+      : null;
+  if (!resolvedEnvPath) return null;
 
   const hasCompose =
     existsSync(path.join(worktreePath, "docker-compose.yml")) ||
@@ -142,7 +148,7 @@ async function readDockerInfo(worktreePath: string) {
 
   if (!hasCompose) return null;
 
-  const raw = await readFile(envPath, "utf-8");
+  const raw = await readFile(resolvedEnvPath, "utf-8");
   const env: Record<string, string> = {};
   for (const line of raw.split("\n")) {
     const match = line.match(/^([A-Z_]+)=(.*)$/);

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -142,7 +142,9 @@ async function readDockerInfo(worktreePath: string) {
       ? examplePath
       : null;
   if (!resolvedEnvPath) return null;
-  const envSource = hasWorktreeEnv ? ("worktree" as const) : ("example" as const);
+  const envSource = hasWorktreeEnv
+    ? ("worktree" as const)
+    : ("example" as const);
 
   const hasCompose =
     existsSync(path.join(worktreePath, "docker-compose.yml")) ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -456,8 +456,10 @@ docker
         console.error("No worktree found");
         process.exit(1);
       }
-      if (!wt.docker) {
-        console.error(`No .env.worktree found in ${wt.path}`);
+      if (!wt.docker || wt.docker.envSource !== "worktree") {
+        console.error(
+          `No .env.worktree found in ${wt.path} — run "grove start" first`,
+        );
         process.exit(1);
       }
 
@@ -531,8 +533,10 @@ docker
         console.error("No worktree found");
         process.exit(1);
       }
-      if (!wt.docker) {
-        console.error(`No .env.worktree found in ${wt.path}`);
+      if (!wt.docker || wt.docker.envSource !== "worktree") {
+        console.error(
+          `No .env.worktree found in ${wt.path} — run "grove start" first`,
+        );
         process.exit(1);
       }
       const { projectName } = wt.docker;
@@ -569,8 +573,10 @@ docker
         console.error("No worktree found");
         process.exit(1);
       }
-      if (!wt.docker) {
-        console.error(`No .env.worktree found in ${wt.path}`);
+      if (!wt.docker || wt.docker.envSource !== "worktree") {
+        console.error(
+          `No .env.worktree found in ${wt.path} — run "grove start" first`,
+        );
         process.exit(1);
       }
       const { projectName } = wt.docker;
@@ -767,6 +773,7 @@ program
         // Bring down docker stack first if running, to avoid orphaned containers
         if (
           wt.docker &&
+          wt.docker.envSource === "worktree" &&
           wt.docker.state !== "not started" &&
           wt.docker.state !== "stopped"
         ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface DockerInfo {
   localstackPort?: number;
   redisDb?: string;
   dbSchema?: string;
+  envSource: "worktree" | "example";
 }
 
 export interface GitChange {


### PR DESCRIPTION
## Summary
- `readDockerInfo` now resolves the env file path by checking `.env.worktree` first, then `.env.example` as a fallback
- Returns `null` only when neither file exists
- Lets grove display docker context (project name, ports, container state) for worktrees that have a committed `.env.example` but haven't had `grove start` run yet

## Test plan
- [ ] In a worktree with `.env.worktree` — behavior unchanged
- [ ] In a worktree with only `.env.example` — docker info is now populated in `grove status` and the TUI
- [ ] In a worktree with neither file — returns null (no docker info shown), same as before

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)