### PR TITLE
Feat: add n key to TUI for creating new worktrees interactively

### DIFF
--- a/src/data/worktrees.test.ts
+++ b/src/data/worktrees.test.ts
@@ -3,18 +3,27 @@ import type { MockedFunction } from "vitest";
 
 vi.mock("execa", () => ({ execa: vi.fn() }));
 vi.mock("fs", () => ({ existsSync: vi.fn().mockReturnValue(false) }));
-vi.mock("fs/promises", () => ({ readFile: vi.fn() }));
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn(),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { execa } from "execa";
 import { existsSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
 import {
   resolveWorktreeRoot,
   detectRepoRoot,
   loadWorktrees,
+  detectDefaultBranch,
+  createWorktreeWithBase,
 } from "./worktrees.js";
 
 const mockedExeca = execa as MockedFunction<typeof execa>;
 const mockedExistsSync = existsSync as MockedFunction<typeof existsSync>;
+const mockedMkdir = mkdir as MockedFunction<typeof mkdir>;
+const mockedWriteFile = writeFile as MockedFunction<typeof writeFile>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -238,5 +247,65 @@ describe("loadWorktrees", () => {
     const { worktrees } = await loadWorktrees("/repo");
     expect(worktrees[0].changeFootprint).not.toBeNull();
     expect(worktrees[0].changeFootprint?.totalFiles).toBeGreaterThan(0);
+  });
+});
+
+describe("detectDefaultBranch", () => {
+  test("returns branch name from origin/HEAD when configured", async () => {
+    mockedExeca.mockResolvedValueOnce({
+      stdout: "origin/main\n",
+    } as ReturnType<typeof execa>);
+    expect(await detectDefaultBranch("/repo")).toBe("main");
+  });
+
+  test("falls back to local main when origin/HEAD not configured", async () => {
+    mockedExeca.mockRejectedValueOnce(new Error("no origin/HEAD"));
+    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<typeof execa>);
+    expect(await detectDefaultBranch("/repo")).toBe("main");
+  });
+
+  test("falls back to origin/main when local main is absent", async () => {
+    mockedExeca.mockRejectedValueOnce(new Error("no origin/HEAD"));
+    mockedExeca.mockRejectedValueOnce(new Error("no local main"));
+    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<typeof execa>);
+    expect(await detectDefaultBranch("/repo")).toBe("main");
+  });
+
+  test("falls back to local master when main is absent in both local and remote", async () => {
+    mockedExeca.mockRejectedValueOnce(new Error("no origin/HEAD"));
+    mockedExeca.mockRejectedValueOnce(new Error("no local main"));
+    mockedExeca.mockRejectedValueOnce(new Error("no origin/main"));
+    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<typeof execa>);
+    expect(await detectDefaultBranch("/repo")).toBe("master");
+  });
+
+  test("returns main as ultimate fallback when nothing is found", async () => {
+    mockedExeca.mockRejectedValue(new Error("not found"));
+    expect(await detectDefaultBranch("/repo")).toBe("main");
+  });
+});
+
+describe("createWorktreeWithBase", () => {
+  test("runs git worktree add with correct arguments", async () => {
+    mockedExeca.mockResolvedValue({ stdout: "" } as ReturnType<typeof execa>);
+    await createWorktreeWithBase("/repo", "feature-foo", "/worktrees/feature-foo", "main");
+    expect(mockedExeca).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "add", "-b", "feature-foo", "/worktrees/feature-foo", "main"],
+      { cwd: "/repo" },
+    );
+  });
+
+  test("writes .grove/meta.json with the base branch", async () => {
+    mockedExeca.mockResolvedValue({ stdout: "" } as ReturnType<typeof execa>);
+    await createWorktreeWithBase("/repo", "feature-foo", "/worktrees/feature-foo", "main");
+    expect(mockedMkdir).toHaveBeenCalledWith(
+      "/worktrees/feature-foo/.grove",
+      { recursive: true },
+    );
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/worktrees/feature-foo/.grove/meta.json",
+      JSON.stringify({ baseBranch: "main" }, null, 2),
+    );
   });
 });

--- a/src/data/worktrees.test.ts
+++ b/src/data/worktrees.test.ts
@@ -260,14 +260,18 @@ describe("detectDefaultBranch", () => {
 
   test("falls back to local main when origin/HEAD not configured", async () => {
     mockedExeca.mockRejectedValueOnce(new Error("no origin/HEAD"));
-    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<typeof execa>);
+    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<
+      typeof execa
+    >);
     expect(await detectDefaultBranch("/repo")).toBe("main");
   });
 
   test("falls back to origin/main when local main is absent", async () => {
     mockedExeca.mockRejectedValueOnce(new Error("no origin/HEAD"));
     mockedExeca.mockRejectedValueOnce(new Error("no local main"));
-    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<typeof execa>);
+    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<
+      typeof execa
+    >);
     expect(await detectDefaultBranch("/repo")).toBe("main");
   });
 
@@ -275,7 +279,9 @@ describe("detectDefaultBranch", () => {
     mockedExeca.mockRejectedValueOnce(new Error("no origin/HEAD"));
     mockedExeca.mockRejectedValueOnce(new Error("no local main"));
     mockedExeca.mockRejectedValueOnce(new Error("no origin/main"));
-    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<typeof execa>);
+    mockedExeca.mockResolvedValueOnce({ stdout: "" } as ReturnType<
+      typeof execa
+    >);
     expect(await detectDefaultBranch("/repo")).toBe("master");
   });
 
@@ -288,21 +294,37 @@ describe("detectDefaultBranch", () => {
 describe("createWorktreeWithBase", () => {
   test("runs git worktree add with correct arguments", async () => {
     mockedExeca.mockResolvedValue({ stdout: "" } as ReturnType<typeof execa>);
-    await createWorktreeWithBase("/repo", "feature-foo", "/worktrees/feature-foo", "main");
+    await createWorktreeWithBase(
+      "/repo",
+      "feature-foo",
+      "/worktrees/feature-foo",
+      "main",
+    );
     expect(mockedExeca).toHaveBeenCalledWith(
       "git",
-      ["worktree", "add", "-b", "feature-foo", "/worktrees/feature-foo", "main"],
+      [
+        "worktree",
+        "add",
+        "-b",
+        "feature-foo",
+        "/worktrees/feature-foo",
+        "main",
+      ],
       { cwd: "/repo" },
     );
   });
 
   test("writes .grove/meta.json with the base branch", async () => {
     mockedExeca.mockResolvedValue({ stdout: "" } as ReturnType<typeof execa>);
-    await createWorktreeWithBase("/repo", "feature-foo", "/worktrees/feature-foo", "main");
-    expect(mockedMkdir).toHaveBeenCalledWith(
-      "/worktrees/feature-foo/.grove",
-      { recursive: true },
+    await createWorktreeWithBase(
+      "/repo",
+      "feature-foo",
+      "/worktrees/feature-foo",
+      "main",
     );
+    expect(mockedMkdir).toHaveBeenCalledWith("/worktrees/feature-foo/.grove", {
+      recursive: true,
+    });
     expect(mockedWriteFile).toHaveBeenCalledWith(
       "/worktrees/feature-foo/.grove/meta.json",
       JSON.stringify({ baseBranch: "main" }, null, 2),

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -1,5 +1,5 @@
 import { execa } from "execa";
-import { readFile } from "fs/promises";
+import { readFile, mkdir, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import type { Worktree, ChangeFootprint, GitChange, PRInfo } from "../types.js";
@@ -376,15 +376,34 @@ export async function detectDefaultBranch(repoPath: string): Promise<string> {
   }
 
   for (const candidate of ["main", "master"]) {
-    try {
-      await execa("git", ["rev-parse", "--verify", candidate], {
-        cwd: repoPath,
-      });
-      return candidate;
-    } catch {
-      // branch doesn't exist
+    for (const ref of [candidate, `origin/${candidate}`]) {
+      try {
+        await execa("git", ["rev-parse", "--verify", ref], { cwd: repoPath });
+        return candidate;
+      } catch {
+        // ref doesn't exist, try next
+      }
     }
   }
 
   return "main";
+}
+
+export async function createWorktreeWithBase(
+  repoPath: string,
+  branch: string,
+  worktreePath: string,
+  base: string,
+): Promise<void> {
+  await execa(
+    "git",
+    ["worktree", "add", "-b", branch, worktreePath, base],
+    { cwd: repoPath },
+  );
+  const groveMetaDir = path.join(worktreePath, ".grove");
+  await mkdir(groveMetaDir, { recursive: true });
+  await writeFile(
+    path.join(groveMetaDir, "meta.json"),
+    JSON.stringify({ baseBranch: base }, null, 2),
+  );
 }

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -395,11 +395,9 @@ export async function createWorktreeWithBase(
   worktreePath: string,
   base: string,
 ): Promise<void> {
-  await execa(
-    "git",
-    ["worktree", "add", "-b", branch, worktreePath, base],
-    { cwd: repoPath },
-  );
+  await execa("git", ["worktree", "add", "-b", branch, worktreePath, base], {
+    cwd: repoPath,
+  });
   const groveMetaDir = path.join(worktreePath, ".grove");
   await mkdir(groveMetaDir, { recursive: true });
   await writeFile(

--- a/src/data/worktrees.ts
+++ b/src/data/worktrees.ts
@@ -361,3 +361,30 @@ export async function detectRepoRoot(): Promise<string> {
     throw new Error("Not inside a git repository");
   }
 }
+
+export async function detectDefaultBranch(repoPath: string): Promise<string> {
+  try {
+    const { stdout } = await execa(
+      "git",
+      ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+      { cwd: repoPath },
+    );
+    const ref = stdout.trim();
+    if (ref) return ref.replace(/^[^/]+\//, "");
+  } catch {
+    // remote HEAD not configured
+  }
+
+  for (const candidate of ["main", "master"]) {
+    try {
+      await execa("git", ["rev-parse", "--verify", candidate], {
+        cwd: repoPath,
+      });
+      return candidate;
+    } catch {
+      // branch doesn't exist
+    }
+  }
+
+  return "main";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   loadWorktrees,
   detectRepoRoot,
   resolveWorktreeRoot,
+  createWorktreeWithBase,
 } from "./data/worktrees.js";
 import { printStatus } from "./commands/status.js";
 import { App } from "./tui/App.js";
@@ -231,19 +232,7 @@ program
               repoGroveConfig?.worktrees?.defaultBaseBranch ??
               "main";
             if (!opts.json) console.log(`  branching off ${base}`);
-            await execa(
-              "git",
-              ["worktree", "add", "-b", branch, worktreePath, base],
-              { cwd: repoPath },
-            );
-            // Record base branch so grove can display it later
-            const groveMetaDir = pathMod.join(worktreePath, ".grove");
-            const { mkdir } = await import("fs/promises");
-            await mkdir(groveMetaDir, { recursive: true });
-            await writeFile(
-              pathMod.join(groveMetaDir, "meta.json"),
-              JSON.stringify({ baseBranch: base }, null, 2),
-            );
+            await createWorktreeWithBase(repoPath, branch, worktreePath, base);
           } else {
             await execa("git", ["fetch", "origin", branch], { cwd: repoPath });
             await execa("git", ["worktree", "add", worktreePath, branch], {

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -5,6 +5,13 @@ import { render } from "./render-for-test.js";
 
 vi.mock("../data/worktrees.js", () => ({
   loadWorktrees: vi.fn(),
+  detectDefaultBranch: vi.fn().mockResolvedValue("main"),
+  resolveWorktreeRoot: vi.fn().mockReturnValue("/repo-worktrees"),
+  createWorktreeWithBase: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../data/groveConfig.js", () => ({
+  loadGroveConfig: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("./editor.js", () => ({
@@ -16,12 +23,14 @@ vi.mock("execa", () => ({
 }));
 
 import { App } from "./App.js";
-import { loadWorktrees } from "../data/worktrees.js";
+import {
+  loadWorktrees,
+  createWorktreeWithBase,
+} from "../data/worktrees.js";
 import type { Worktree } from "../types.js";
 
-const mockedLoadWorktrees = loadWorktrees as MockedFunction<
-  typeof loadWorktrees
->;
+const mockedLoadWorktrees = loadWorktrees as MockedFunction<typeof loadWorktrees>;
+const mockedCreateWorktreeWithBase = createWorktreeWithBase as MockedFunction<typeof createWorktreeWithBase>;
 
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
   return {
@@ -297,5 +306,86 @@ describe("App — help view", () => {
     await wait();
     expect(lastFrame()).not.toContain("Keyboard Shortcuts");
     expect(lastFrame()).toContain("grove");
+  });
+});
+
+describe("App — new worktree flow", () => {
+  test("pressing n shows branch name prompt", async () => {
+    const { lastFrame, stdin } = render(
+      <App repoPath="/repo" initialWorktrees={[makeWorktree()]} />,
+    );
+    stdin.write("n");
+    await wait();
+    expect(lastFrame()).toContain("branch name");
+  });
+
+  test("entering a branch name advances to base branch prompt", async () => {
+    const { lastFrame, stdin } = render(
+      <App repoPath="/repo" initialWorktrees={[makeWorktree()]} />,
+    );
+    stdin.write("n");
+    await wait();
+    stdin.write("f");
+    stdin.write("o");
+    stdin.write("o");
+    await wait();
+    stdin.write("\r");
+    await wait();
+    expect(lastFrame()).toContain("base branch");
+  });
+
+  test("Esc at name step cancels and returns to main view", async () => {
+    const { lastFrame, stdin } = render(
+      <App repoPath="/repo" initialWorktrees={[makeWorktree()]} />,
+    );
+    stdin.write("n");
+    await wait();
+    expect(lastFrame()).toContain("branch name");
+    stdin.write("");
+    await wait();
+    expect(lastFrame()).not.toContain("branch name");
+    expect(lastFrame()).toContain("sync");
+  });
+
+  test("Esc at base step cancels and returns to main view", async () => {
+    const { lastFrame, stdin } = render(
+      <App repoPath="/repo" initialWorktrees={[makeWorktree()]} />,
+    );
+    stdin.write("n");
+    await wait();
+    stdin.write("f");
+    stdin.write("o");
+    stdin.write("o");
+    await wait();
+    stdin.write("\r");
+    await wait();
+    expect(lastFrame()).toContain("base branch");
+    stdin.write("");
+    await wait();
+    expect(lastFrame()).not.toContain("base branch");
+    expect(lastFrame()).toContain("sync");
+  });
+
+  test("submitting empty base calls createWorktreeWithBase with detected default", async () => {
+    mockedLoadWorktrees.mockResolvedValue({ worktrees: [makeWorktree()], ghWarning: null });
+    const { stdin } = render(
+      <App repoPath="/repo" initialWorktrees={[makeWorktree()]} />,
+    );
+    stdin.write("n");
+    await wait();
+    stdin.write("f");
+    await wait();
+    stdin.write("o");
+    await wait();
+    stdin.write("\r");
+    await wait();
+    stdin.write("\r");
+    await wait(100);
+    expect(mockedCreateWorktreeWithBase).toHaveBeenCalledWith(
+      "/repo",
+      "fo",
+      expect.stringContaining("fo"),
+      "main",
+    );
   });
 });

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -23,14 +23,15 @@ vi.mock("execa", () => ({
 }));
 
 import { App } from "./App.js";
-import {
-  loadWorktrees,
-  createWorktreeWithBase,
-} from "../data/worktrees.js";
+import { loadWorktrees, createWorktreeWithBase } from "../data/worktrees.js";
 import type { Worktree } from "../types.js";
 
-const mockedLoadWorktrees = loadWorktrees as MockedFunction<typeof loadWorktrees>;
-const mockedCreateWorktreeWithBase = createWorktreeWithBase as MockedFunction<typeof createWorktreeWithBase>;
+const mockedLoadWorktrees = loadWorktrees as MockedFunction<
+  typeof loadWorktrees
+>;
+const mockedCreateWorktreeWithBase = createWorktreeWithBase as MockedFunction<
+  typeof createWorktreeWithBase
+>;
 
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
   return {
@@ -367,7 +368,10 @@ describe("App — new worktree flow", () => {
   });
 
   test("submitting empty base calls createWorktreeWithBase with detected default", async () => {
-    mockedLoadWorktrees.mockResolvedValue({ worktrees: [makeWorktree()], ghWarning: null });
+    mockedLoadWorktrees.mockResolvedValue({
+      worktrees: [makeWorktree()],
+      ghWarning: null,
+    });
     const { stdin } = render(
       <App repoPath="/repo" initialWorktrees={[makeWorktree()]} />,
     );

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useCallback } from "react";
 import { Box, Text, useInput, useApp } from "ink";
+import TextInput from "ink-text-input";
 import { execa } from "execa";
 import type { Worktree } from "../types.js";
 import { openInEditor } from "./editor.js";
-import { loadWorktrees } from "../data/worktrees.js";
+import { loadWorktrees, detectDefaultBranch, resolveWorktreeRoot } from "../data/worktrees.js";
 import { WorktreeList } from "./WorktreeList.js";
 import { DetailPanel } from "./DetailPanel.js";
 import { CompactFootprint } from "./ChangeFootprint.js";
@@ -12,7 +13,8 @@ import { FilterBar } from "./FilterBar.js";
 import { useTerminalSize } from "./useTerminalSize.js";
 import { LOGO } from "./logo.js";
 
-type AppView = "main" | "help" | "confirmDelete";
+type AppView = "main" | "help" | "confirmDelete" | "newWorktree";
+type NewWorktreeStep = "name" | "base";
 
 interface AppProps {
   repoPath: string;
@@ -31,6 +33,9 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
   const [view, setView] = useState<AppView>("main");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
+  const [newWorktreeStep, setNewWorktreeStep] = useState<NewWorktreeStep>("name");
+  const [newWorktreeName, setNewWorktreeName] = useState("");
+  const [newWorktreeBase, setNewWorktreeBase] = useState("");
 
   const filteredWorktrees = worktrees.filter((wt) => {
     if (!filterText) return true;
@@ -155,6 +160,31 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
     }
   }, [selectedWorktree, flash, handleSync]);
 
+  const handleNewWorktree = useCallback(async (name: string, base: string) => {
+    try {
+      const { join } = await import("path");
+      const { mkdir, writeFile } = await import("fs/promises");
+      const { loadGroveConfig } = await import("../data/groveConfig.js");
+
+      const groveConfig = await loadGroveConfig(repoPath);
+      const worktreeRoot = resolveWorktreeRoot(repoPath, groveConfig?.worktrees?.root);
+      const resolvedBase = base.trim() || (await detectDefaultBranch(repoPath));
+      const worktreePath = join(worktreeRoot, name.replace(/\//g, "-"));
+
+      flash(`creating ${name}…`);
+      await execa("git", ["worktree", "add", "-b", name, worktreePath, resolvedBase], { cwd: repoPath });
+
+      const groveMetaDir = join(worktreePath, ".grove");
+      await mkdir(groveMetaDir, { recursive: true });
+      await writeFile(join(groveMetaDir, "meta.json"), JSON.stringify({ baseBranch: resolvedBase }, null, 2));
+
+      flash(`created ${name}`);
+      await handleSync();
+    } catch (err) {
+      flash(`create failed: ${(err as Error).message}`);
+    }
+  }, [repoPath, flash, handleSync]);
+
   useInput((input, key) => {
     if (filterActive) {
       if (key.escape) {
@@ -180,6 +210,16 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
       return;
     }
 
+    if (view === "newWorktree") {
+      if (key.escape) {
+        setView("main");
+        setNewWorktreeName("");
+        setNewWorktreeBase("");
+        setNewWorktreeStep("name");
+      }
+      return;
+    }
+
     if (input === "D" && selectedWorktree && !selectedWorktree.isMain) {
       setView("confirmDelete");
       return;
@@ -194,6 +234,13 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
     }
     if (input === "s") {
       void handleSync();
+      return;
+    }
+    if (input === "n") {
+      setNewWorktreeName("");
+      setNewWorktreeBase("");
+      setNewWorktreeStep("name");
+      setView("newWorktree");
       return;
     }
     if (input === "o") {
@@ -249,6 +296,9 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
         </Text>
         <Text>
           <Text color="cyan">↓/j</Text> <Text color="gray">move down</Text>
+        </Text>
+        <Text>
+          <Text color="cyan">n</Text> <Text color="gray">new worktree</Text>
         </Text>
         <Text>
           <Text color="cyan">s</Text> <Text color="gray">sync worktrees</Text>
@@ -338,6 +388,34 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
             setFilterText("");
           }}
         />
+      ) : view === "newWorktree" && newWorktreeStep === "name" ? (
+        <Box paddingX={1}>
+          <Text color="cyan">new  </Text>
+          <TextInput
+            value={newWorktreeName}
+            onChange={setNewWorktreeName}
+            onSubmit={(val) => {
+              if (val.trim()) setNewWorktreeStep("base");
+              else setView("main");
+            }}
+            placeholder="branch name..."
+          />
+          <Text color="gray"> (Esc to cancel)</Text>
+        </Box>
+      ) : view === "newWorktree" && newWorktreeStep === "base" ? (
+        <Box paddingX={1}>
+          <Text color="cyan">base </Text>
+          <TextInput
+            value={newWorktreeBase}
+            onChange={setNewWorktreeBase}
+            onSubmit={(val) => {
+              setView("main");
+              void handleNewWorktree(newWorktreeName, val);
+            }}
+            placeholder="base branch (empty = repo default)..."
+          />
+          <Text color="gray"> (Esc to cancel)</Text>
+        </Box>
       ) : view === "confirmDelete" ? (
         <Box paddingX={1}>
           <Text color="red">Delete </Text>

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -4,7 +4,11 @@ import TextInput from "ink-text-input";
 import { execa } from "execa";
 import type { Worktree } from "../types.js";
 import { openInEditor } from "./editor.js";
-import { loadWorktrees, detectDefaultBranch, resolveWorktreeRoot } from "../data/worktrees.js";
+import {
+  loadWorktrees,
+  detectDefaultBranch,
+  resolveWorktreeRoot,
+} from "../data/worktrees.js";
 import { WorktreeList } from "./WorktreeList.js";
 import { DetailPanel } from "./DetailPanel.js";
 import { CompactFootprint } from "./ChangeFootprint.js";
@@ -33,7 +37,8 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
   const [view, setView] = useState<AppView>("main");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
-  const [newWorktreeStep, setNewWorktreeStep] = useState<NewWorktreeStep>("name");
+  const [newWorktreeStep, setNewWorktreeStep] =
+    useState<NewWorktreeStep>("name");
   const [newWorktreeName, setNewWorktreeName] = useState("");
   const [newWorktreeBase, setNewWorktreeBase] = useState("");
 
@@ -160,30 +165,44 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
     }
   }, [selectedWorktree, flash, handleSync]);
 
-  const handleNewWorktree = useCallback(async (name: string, base: string) => {
-    try {
-      const { join } = await import("path");
-      const { mkdir, writeFile } = await import("fs/promises");
-      const { loadGroveConfig } = await import("../data/groveConfig.js");
+  const handleNewWorktree = useCallback(
+    async (name: string, base: string) => {
+      try {
+        const { join } = await import("path");
+        const { mkdir, writeFile } = await import("fs/promises");
+        const { loadGroveConfig } = await import("../data/groveConfig.js");
 
-      const groveConfig = await loadGroveConfig(repoPath);
-      const worktreeRoot = resolveWorktreeRoot(repoPath, groveConfig?.worktrees?.root);
-      const resolvedBase = base.trim() || (await detectDefaultBranch(repoPath));
-      const worktreePath = join(worktreeRoot, name.replace(/\//g, "-"));
+        const groveConfig = await loadGroveConfig(repoPath);
+        const worktreeRoot = resolveWorktreeRoot(
+          repoPath,
+          groveConfig?.worktrees?.root,
+        );
+        const resolvedBase =
+          base.trim() || (await detectDefaultBranch(repoPath));
+        const worktreePath = join(worktreeRoot, name.replace(/\//g, "-"));
 
-      flash(`creating ${name}…`);
-      await execa("git", ["worktree", "add", "-b", name, worktreePath, resolvedBase], { cwd: repoPath });
+        flash(`creating ${name}…`);
+        await execa(
+          "git",
+          ["worktree", "add", "-b", name, worktreePath, resolvedBase],
+          { cwd: repoPath },
+        );
 
-      const groveMetaDir = join(worktreePath, ".grove");
-      await mkdir(groveMetaDir, { recursive: true });
-      await writeFile(join(groveMetaDir, "meta.json"), JSON.stringify({ baseBranch: resolvedBase }, null, 2));
+        const groveMetaDir = join(worktreePath, ".grove");
+        await mkdir(groveMetaDir, { recursive: true });
+        await writeFile(
+          join(groveMetaDir, "meta.json"),
+          JSON.stringify({ baseBranch: resolvedBase }, null, 2),
+        );
 
-      flash(`created ${name}`);
-      await handleSync();
-    } catch (err) {
-      flash(`create failed: ${(err as Error).message}`);
-    }
-  }, [repoPath, flash, handleSync]);
+        flash(`created ${name}`);
+        await handleSync();
+      } catch (err) {
+        flash(`create failed: ${(err as Error).message}`);
+      }
+    },
+    [repoPath, flash, handleSync],
+  );
 
   useInput((input, key) => {
     if (filterActive) {
@@ -390,7 +409,7 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
         />
       ) : view === "newWorktree" && newWorktreeStep === "name" ? (
         <Box paddingX={1}>
-          <Text color="cyan">new  </Text>
+          <Text color="cyan">new </Text>
           <TextInput
             value={newWorktreeName}
             onChange={setNewWorktreeName}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -183,7 +183,12 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
         const worktreePath = path.join(worktreeRoot, name.replace(/\//g, "-"));
 
         flash(`creating ${name}…`);
-        await createWorktreeWithBase(repoPath, name, worktreePath, resolvedBase);
+        await createWorktreeWithBase(
+          repoPath,
+          name,
+          worktreePath,
+          resolvedBase,
+        );
         flash(`created ${name}`);
         await handleSync();
       } catch (err) {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import path from "path";
 import { Box, Text, useInput, useApp } from "ink";
 import TextInput from "ink-text-input";
 import { execa } from "execa";
@@ -8,7 +9,9 @@ import {
   loadWorktrees,
   detectDefaultBranch,
   resolveWorktreeRoot,
+  createWorktreeWithBase,
 } from "../data/worktrees.js";
+import { loadGroveConfig } from "../data/groveConfig.js";
 import { WorktreeList } from "./WorktreeList.js";
 import { DetailPanel } from "./DetailPanel.js";
 import { CompactFootprint } from "./ChangeFootprint.js";
@@ -168,33 +171,19 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
   const handleNewWorktree = useCallback(
     async (name: string, base: string) => {
       try {
-        const { join } = await import("path");
-        const { mkdir, writeFile } = await import("fs/promises");
-        const { loadGroveConfig } = await import("../data/groveConfig.js");
-
         const groveConfig = await loadGroveConfig(repoPath);
         const worktreeRoot = resolveWorktreeRoot(
           repoPath,
           groveConfig?.worktrees?.root,
         );
         const resolvedBase =
-          base.trim() || (await detectDefaultBranch(repoPath));
-        const worktreePath = join(worktreeRoot, name.replace(/\//g, "-"));
+          base.trim() ||
+          groveConfig?.worktrees?.defaultBaseBranch ||
+          (await detectDefaultBranch(repoPath));
+        const worktreePath = path.join(worktreeRoot, name.replace(/\//g, "-"));
 
         flash(`creating ${name}…`);
-        await execa(
-          "git",
-          ["worktree", "add", "-b", name, worktreePath, resolvedBase],
-          { cwd: repoPath },
-        );
-
-        const groveMetaDir = join(worktreePath, ".grove");
-        await mkdir(groveMetaDir, { recursive: true });
-        await writeFile(
-          join(groveMetaDir, "meta.json"),
-          JSON.stringify({ baseBranch: resolvedBase }, null, 2),
-        );
-
+        await createWorktreeWithBase(repoPath, name, worktreePath, resolvedBase);
         flash(`created ${name}`);
         await handleSync();
       } catch (err) {
@@ -414,8 +403,13 @@ export function App({ repoPath, initialWorktrees }: AppProps) {
             value={newWorktreeName}
             onChange={setNewWorktreeName}
             onSubmit={(val) => {
-              if (val.trim()) setNewWorktreeStep("base");
-              else setView("main");
+              const trimmed = val.trim();
+              if (trimmed) {
+                setNewWorktreeName(trimmed);
+                setNewWorktreeStep("base");
+              } else {
+                setView("main");
+              }
             }}
             placeholder="branch name..."
           />

--- a/src/tui/KeybindBar.test.tsx
+++ b/src/tui/KeybindBar.test.tsx
@@ -23,6 +23,8 @@ describe("KeybindBar", () => {
   test("shows base keys when no worktree is selected", () => {
     const { lastFrame } = render(<KeybindBar worktree={null} />);
     const frame = lastFrame()!;
+    expect(frame).toContain("n");
+    expect(frame).toContain("new");
     expect(frame).toContain("s");
     expect(frame).toContain("sync");
     expect(frame).toContain("?");

--- a/src/tui/KeybindBar.tsx
+++ b/src/tui/KeybindBar.tsx
@@ -13,6 +13,7 @@ interface Key {
 
 export function KeybindBar({ worktree }: KeybindBarProps) {
   const keys: Key[] = [
+    { key: "n", label: "new" },
     { key: "s", label: "sync" },
     { key: "?", label: "help" },
     { key: "q", label: "quit" },


### PR DESCRIPTION
## Summary
- Pressing `n` in the grove TUI opens a two-step inline prompt: branch name, then base branch
- Empty base branch auto-detects the repo's default branch (via `origin/HEAD`, falling back to `main`/`master`)
- After both are entered, creates the worktree with `git worktree add -b` and writes `.grove/meta.json` with the base branch recorded
- The list refreshes automatically after creation
- Esc cancels at either step
- `n new` now appears in the KeybindBar and help screen

Note: `s` is already bound to sync, so `n` (for "new") was used instead.

## Test plan
- [ ] Press `n` in the TUI — branch name prompt appears at the bottom
- [ ] Type a branch name and press Enter — base branch prompt appears
- [ ] Press Enter with empty base — uses repo default branch
- [ ] Type a base branch and press Enter — worktree is created and list refreshes
- [ ] Press Esc at either step — returns to main view with no changes
- [ ] `?` help screen shows the `n new` binding

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)