### PR TITLE
Feature/support artbitrary service ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ Proposed .grove/config.json:
 Write .grove/config.json? (y/N)
 ```
 
-Grove only writes `.grove/config.json`. It never touches `docker-compose.yml`, `package.json`, `.env`, or any other project file.
+By default, `grove setup` only writes `.grove/config.json`.
+
+When you pass `--refresh-env`, Grove also regenerates `.env.worktree` in the current worktree using naming rules plus env contract resolution.
 
 ### Flags
 
@@ -208,9 +210,55 @@ For arbitrary services (redis, localstack, mailhog, etc.), prefer `naming.ports`
 Grove inspects your Compose contract and generates compatibility aliases automatically.
 
 - Canonical Grove keys remain the source of truth (`WEB_PORT`, `API_PORT`, `DB_PORT`, `DB_SCHEMA`, `COMPOSE_PROJECT_NAME`).
-- If Compose expects alternative keys (for example `APP_PORT`, `POSTGRES_PORT`, `POSTGRES_DB`), Grove adds those aliases to `.env.worktree` with matching values.
+- If Compose expects alternative **port/project** keys (for example `APP_PORT` or `POSTGRES_PORT`), Grove adds deterministic aliases to `.env.worktree` with matching values.
+- Grove does **not** guess semantic or credential-like values (for example `DATABASE_URL`, `POSTGRES_PASSWORD`, `DB_USER`). Configure those via `envContract` templates or passthrough rules.
 - Detection uses `docker compose config --no-interpolate --format json` when available, falls back to Compose text scanning, and also reads `docker compose config --variables` when supported.
 - If Docker CLI is unavailable during detection, Grove warns and continues with existing behavior.
+
+### Dynamic vars and envContract
+
+Grove treats environment variables in classes so dynamic values stay predictable and safe:
+
+- `managed`: Grove-owned deterministic values (for example ports and project name)
+- `derived`: rendered from explicit templates
+- `passthrough`: copied unchanged from source env files
+- `required`: must be present after rendering
+
+Recommended baseline:
+
+- Let Grove manage deterministic infra vars (`*_PORT`, `COMPOSE_PROJECT_NAME`, and optionally `DB_SCHEMA`).
+- Keep semantic/secret vars template-driven or passthrough.
+- Avoid heuristic generation for app-level vars such as `DATABASE_URL`.
+
+Example:
+
+```json
+{
+  "envContract": {
+    "strict": true,
+    "passthrough": [
+      "POSTGRES_USER",
+      "POSTGRES_PASSWORD",
+      "POSTGRES_DB",
+      "FEATURE_FLAG"
+    ],
+    "derived": {
+      "DATABASE_URL": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=${DB_SCHEMA}"
+    },
+    "required": ["DATABASE_URL"],
+    "sourceEnvFiles": [".env"]
+  }
+}
+```
+
+Resolution behavior:
+
+- Deterministic aliases are created for port/project vars discovered in Compose.
+- `passthrough` vars are copied from source env files (default: `.env`) and existing `.env.worktree` values.
+- `derived` vars are rendered only from explicit templates.
+- If a derived template cannot be fully rendered:
+  - non-strict mode: Grove keeps an existing source value when available and warns
+  - strict mode (or `required`): Grove fails with an actionable error
 
 ---
 
@@ -293,6 +341,15 @@ For full control over how Grove manages environments, add `.grove/config.json` t
     "webPort": "auto",
     "apiPort": "auto"
   },
+  "envContract": {
+    "strict": true,
+    "passthrough": ["POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"],
+    "derived": {
+      "DATABASE_URL": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=${DB_SCHEMA}"
+    },
+    "required": ["DATABASE_URL"],
+    "sourceEnvFiles": [".env"]
+  },
   "worktrees": {
     "root": "/Users/you/worktrees"
   }
@@ -315,6 +372,7 @@ When this file is present, Grove uses it instead of inferring the environment. Y
 | ----------------------------- | -------------------------------- | ------------------------------------------------------------- |
 | `sharedComposeFile`           | `compose.shared.yaml`            | Path to the shared infrastructure compose file                |
 | `editor`                      | auto-detected                    | Editor to open with `grove open` / `o` key                    |
+| `envContract`                 | unset                            | Dynamic env var policy (managed/derived/passthrough/required) |
 | `worktrees.root`              | `<repo-parent>/<repo>-worktrees` | Where new worktrees are placed                                |
 | `worktrees.defaultBaseBranch` | `main`                           | Default base for `grove start --new` when `--base` is omitted |
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Proposed .grove/config.json:
   },
   "shared": { "db": true, "redis": true },
   "naming": {
-    "composeProject": "grove-${branch_safe}",
+    "composeProject": "${project}-${branch_safe}",
     "dbSchema": "my_app_${branch_safe}",
     "ports": {
       "WEB_PORT": "auto",
@@ -144,7 +144,7 @@ Proposed .grove/config.json:
     "webPort": "auto",
     "apiPort": "auto"
   },
-  "worktrees": { "prefix": "grove" }
+  "worktrees": { "prefix": "grove", "defaultBaseBranch": "main" }
 }
 
   Add these to .gitignore (per-worktree, should not be committed):
@@ -162,6 +162,7 @@ Grove only writes `.grove/config.json`. It never touches `docker-compose.yml`, `
 | ----------------- | ------------------------------------------------------------- |
 | `--preset <name>` | Skip detection, use a known preset (`docker`, `vite`, `node`) |
 | `--dry-run`       | Print the proposed config without writing anything            |
+| `--refresh-env`   | Regenerate `.env.worktree` from the resolved Grove config     |
 | `--yes`           | Skip the confirmation prompt                                  |
 | `--reset`         | Overwrite an existing `.grove/config.json`                    |
 
@@ -169,6 +170,7 @@ Grove only writes `.grove/config.json`. It never touches `docker-compose.yml`, `
 grove setup --preset docker --yes     # non-interactive, docker preset
 grove setup --dry-run                 # preview only
 grove setup --reset                   # regenerate from scratch
+grove setup --refresh-env             # regenerate .env.worktree in current worktree
 ```
 
 ### Available presets
@@ -191,7 +193,7 @@ The `naming` section in `.grove/config.json` stores **rules, not values**. Templ
 
 Example:
 
-- `"composeProject": "grove-${branch_safe}"` → `grove-feat-auth-refresh`
+- `"composeProject": "${project}-${branch_safe}"` → `myapp-feat-auth-refresh`
 - `"dbSchema": "${project}_${branch_safe}"` → `myapp_feat_auth_refresh`
 - `"ports": { "REDIS_PORT": "auto" }` → Grove allocates a free host port and writes `REDIS_PORT=<port>`
 - `"dbPort": "auto"` → Grove finds a free DB host port at spin time
@@ -200,6 +202,15 @@ Example:
 This means you never manually assign ports or project names. `grove start` generates the `.env.worktree` file for each new worktree automatically.
 
 For arbitrary services (redis, localstack, mailhog, etc.), prefer `naming.ports` so you are not limited to built-in keys.
+
+### Compose env contract detection and alias generation
+
+Grove inspects your Compose contract and generates compatibility aliases automatically.
+
+- Canonical Grove keys remain the source of truth (`WEB_PORT`, `API_PORT`, `DB_PORT`, `DB_SCHEMA`, `COMPOSE_PROJECT_NAME`).
+- If Compose expects alternative keys (for example `APP_PORT`, `POSTGRES_PORT`, `POSTGRES_DB`), Grove adds those aliases to `.env.worktree` with matching values.
+- Detection uses `docker compose config --no-interpolate --format json` when available, falls back to Compose text scanning, and also reads `docker compose config --variables` when supported.
+- If Docker CLI is unavailable during detection, Grove warns and continues with existing behavior.
 
 ---
 
@@ -224,7 +235,15 @@ REDIS_DB=1                              # informational — shown in TUI card
 DB_SCHEMA=my_app_feat_auth             # informational — shown in TUI card
 ```
 
-Grove reads this file to discover port bindings and the Compose project name. It never writes to it. Each worktree gets its own `.env.worktree` with unique ports and a unique `COMPOSE_PROJECT_NAME` to keep stacks isolated.
+Grove reads this file to discover port bindings and the Compose project name, and can generate or refresh it via `grove start` and `grove setup --refresh-env`. Each worktree gets its own `.env.worktree` with unique ports and a unique `COMPOSE_PROJECT_NAME` to keep stacks isolated.
+
+Before `docker compose up`, Grove runs a preflight resolve (`docker compose --env-file .env.worktree config --format json`) and fails fast on common contract issues:
+
+- missing expected variables
+- published host-port collisions with running containers
+- fallback-to-default port mismatches (for example resolving to `3000` or `5432` when Grove allocated different values)
+
+Error output includes the affected service/variable and an actionable fix.
 
 For Postgres or other host-bound services, make sure your compose file uses the generated env var in its `ports` mapping, for example:
 
@@ -292,11 +311,12 @@ When this file is present, Grove uses it instead of inferring the environment. Y
 
 **Top-level config fields:**
 
-| Field               | Default                          | Description                                    |
-| ------------------- | -------------------------------- | ---------------------------------------------- |
-| `sharedComposeFile` | `compose.shared.yaml`            | Path to the shared infrastructure compose file |
-| `editor`            | auto-detected                    | Editor to open with `grove open` / `o` key     |
-| `worktrees.root`    | `<repo-parent>/<repo>-worktrees` | Where new worktrees are placed                 |
+| Field                         | Default                          | Description                                                   |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------------- |
+| `sharedComposeFile`           | `compose.shared.yaml`            | Path to the shared infrastructure compose file                |
+| `editor`                      | auto-detected                    | Editor to open with `grove open` / `o` key                    |
+| `worktrees.root`              | `<repo-parent>/<repo>-worktrees` | Where new worktrees are placed                                |
+| `worktrees.defaultBaseBranch` | `main`                           | Default base for `grove start --new` when `--base` is omitted |
 
 ---
 
@@ -585,6 +605,9 @@ grove start feat/my-feature --new
 # Create a new branch off a specific base branch
 grove start feat/my-feature --new --base hotfix-from-main-setup
 
+# Force .env.worktree regeneration from current Grove config for this worktree
+grove start feat/my-feature --refresh-env
+
 # Attach to an existing worktree and (re)start its environment
 grove start feat/my-feature
 
@@ -615,8 +638,33 @@ grove docker up feat/my-feature
 grove docker down feat/my-feature
 grove docker teardown feat/my-feature   # destroys volumes — prompts for confirmation
 
+# Diagnose compose env contract vs generated env vars
+grove doctor env feat/my-feature
+
 # Show resolved configuration (worktree root, editor, grove config)
 grove info
+```
+
+### Troubleshooting env mismatches
+
+If `docker compose` appears to ignore Grove ports:
+
+1. Regenerate env for the current worktree:
+
+```bash
+grove setup --refresh-env
+```
+
+2. Inspect contract expectations and missing aliases:
+
+```bash
+grove doctor env
+```
+
+3. For target worktrees started via Grove:
+
+```bash
+grove start feat/my-feature --refresh-env
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ Proposed .grove/config.json:
   "naming": {
     "composeProject": "grove-${branch_safe}",
     "dbSchema": "my_app_${branch_safe}",
+    "ports": {
+      "WEB_PORT": "auto",
+      "API_PORT": "auto",
+      "DB_PORT": "auto"
+    },
+    "dbPort": "auto",
     "webPort": "auto",
     "apiPort": "auto"
   },
@@ -187,9 +193,13 @@ Example:
 
 - `"composeProject": "grove-${branch_safe}"` → `grove-feat-auth-refresh`
 - `"dbSchema": "${project}_${branch_safe}"` → `myapp_feat_auth_refresh`
+- `"ports": { "REDIS_PORT": "auto" }` → Grove allocates a free host port and writes `REDIS_PORT=<port>`
+- `"dbPort": "auto"` → Grove finds a free DB host port at spin time
 - `"webPort": "auto"` → Grove finds a free port at spin time
 
 This means you never manually assign ports or project names. `grove start` generates the `.env.worktree` file for each new worktree automatically.
+
+For arbitrary services (redis, localstack, mailhog, etc.), prefer `naming.ports` so you are not limited to built-in keys.
 
 ---
 
@@ -207,12 +217,23 @@ If your project uses Docker Compose and you want Grove to manage per-worktree st
 # .env.worktree
 COMPOSE_PROJECT_NAME=my-app-feat-auth   # used as `docker compose -p` value
 WEB_PORT=8081                           # primary app URL (shown in TUI, used by agents)
+DB_PORT=5433                            # postgres host port for this worktree
+REDIS_PORT=6380                         # redis host port for this worktree (optional)
 LOCALSTACK_PORT=4567                    # optional secondary service
 REDIS_DB=1                              # informational — shown in TUI card
 DB_SCHEMA=my_app_feat_auth             # informational — shown in TUI card
 ```
 
 Grove reads this file to discover port bindings and the Compose project name. It never writes to it. Each worktree gets its own `.env.worktree` with unique ports and a unique `COMPOSE_PROJECT_NAME` to keep stacks isolated.
+
+For Postgres or other host-bound services, make sure your compose file uses the generated env var in its `ports` mapping, for example:
+
+```yaml
+services:
+  db:
+    ports:
+      - "${DB_PORT:-5432}:5432"
+```
 
 Add `.env.worktree` to your `.gitignore`:
 
@@ -242,6 +263,14 @@ For full control over how Grove manages environments, add `.grove/config.json` t
     "composeProject": "my-app-${branch_safe}",
     "sharedProject": "my-app-shared",
     "dbSchema": "my_app_${branch_safe}",
+    "ports": {
+      "WEB_PORT": "auto",
+      "API_PORT": "auto",
+      "DB_PORT": "auto",
+      "REDIS_PORT": "auto",
+      "LOCALSTACK_PORT": "auto"
+    },
+    "dbPort": "auto",
     "webPort": "auto",
     "apiPort": "auto"
   },
@@ -369,6 +398,7 @@ When `naming.sharedProject` is configured, the generated `.env.worktree` looks l
 COMPOSE_PROJECT_NAME=my-app-feat-auth
 WEB_PORT=8081
 API_PORT=8082
+DB_PORT=5433
 DB_SCHEMA=my_app_feat_auth
 SHARED_PROJECT_NAME=my-app-shared
 ```

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -7,10 +7,14 @@ import { presets, recommendPreset, type PresetName } from "../setup/presets.js";
 import type { GroveConfig } from "../types.js";
 import { warnIfHardcodedComposePorts } from "../utils/hardcodedPortsCheck.js";
 import { DEFAULT_SHARED_COMPOSE_FILE } from "../providers/shared.js";
+import { expandNaming, buildEnvAgent } from "../setup/naming.js";
+import { execa } from "execa";
+import { loadGroveConfig } from "../data/groveConfig.js";
 
 export interface SetupOptions {
   preset?: PresetName;
   dryRun?: boolean;
+  refreshEnv?: boolean;
   yes?: boolean;
   reset?: boolean;
 }
@@ -117,6 +121,39 @@ async function writeGroveConfig(
   );
 }
 
+async function resolveCurrentBranch(repoPath: string): Promise<string> {
+  try {
+    const { stdout } = await execa(
+      "git",
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      {
+        cwd: repoPath,
+      },
+    );
+    const branch = stdout.trim();
+    return branch && branch !== "HEAD" ? branch : "main";
+  } catch {
+    return "main";
+  }
+}
+
+async function regenerateEnvFromConfig(
+  repoPath: string,
+  config: GroveConfig,
+): Promise<void> {
+  const branch = await resolveCurrentBranch(repoPath);
+  const envPath = path.join(repoPath, ".env.worktree");
+  const expanded = expandNaming(config, branch);
+  const envContent = await buildEnvAgent(expanded);
+  await writeFile(envPath, envContent, "utf-8");
+
+  console.log(chalk.green("✓ Regenerated .env.worktree"));
+  console.log(chalk.gray(`  branch: ${branch}`));
+  for (const line of envContent.trim().split("\n")) {
+    console.log(chalk.gray(`  ${line}`));
+  }
+}
+
 export async function runSetup(
   repoPath: string,
   opts: SetupOptions = {},
@@ -125,12 +162,27 @@ export async function runSetup(
 
   // Guard: existing config without --reset
   if (existsSync(configPath) && !opts.reset && !opts.dryRun) {
-    console.log(chalk.yellow(".grove/config.json already exists."));
-    console.log(
-      chalk.gray(
-        "  Run with --reset to regenerate it, or --dry-run to preview a new config.",
-      ),
-    );
+    if (!opts.refreshEnv) {
+      console.log(chalk.yellow(".grove/config.json already exists."));
+      console.log(
+        chalk.gray(
+          "  Run with --reset to regenerate it, or --dry-run to preview a new config.",
+        ),
+      );
+      return;
+    }
+
+    const existing = await loadGroveConfig(repoPath);
+    if (!existing) {
+      console.log(
+        chalk.yellow(
+          "Unable to refresh .env.worktree: .grove/config.json is missing, disabled, or invalid.",
+        ),
+      );
+      return;
+    }
+
+    await regenerateEnvFromConfig(repoPath, existing);
     return;
   }
 
@@ -199,4 +251,8 @@ export async function runSetup(
   console.log(chalk.gray("  grove status          — show all worktrees"));
   console.log(chalk.gray("  grove                 — open the TUI"));
   console.log();
+
+  if (opts.refreshEnv) {
+    await regenerateEnvFromConfig(repoPath, config);
+  }
 }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -5,6 +5,8 @@ import chalk from "chalk";
 import { detectProject } from "../setup/detect.js";
 import { presets, recommendPreset, type PresetName } from "../setup/presets.js";
 import type { GroveConfig } from "../types.js";
+import { warnIfHardcodedComposePorts } from "../utils/hardcodedPortsCheck.js";
+import { DEFAULT_SHARED_COMPOSE_FILE } from "../providers/shared.js";
 
 export interface SetupOptions {
   preset?: PresetName;
@@ -158,6 +160,10 @@ export async function runSetup(
 
   // 3. Generate config
   const config = preset.generate(detection);
+
+  await warnIfHardcodedComposePorts(repoPath, [
+    config.sharedComposeFile ?? DEFAULT_SHARED_COMPOSE_FILE,
+  ]);
 
   // 4. Show proposal
   printProposedConfig(config);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -7,16 +7,27 @@ import { presets, recommendPreset, type PresetName } from "../setup/presets.js";
 import type { GroveConfig } from "../types.js";
 import { warnIfHardcodedComposePorts } from "../utils/hardcodedPortsCheck.js";
 import { DEFAULT_SHARED_COMPOSE_FILE } from "../providers/shared.js";
-import { expandNaming, buildEnvAgent } from "../setup/naming.js";
+import { expandNaming, buildCanonicalEnvVars } from "../setup/naming.js";
 import { execa } from "execa";
 import { loadGroveConfig } from "../data/groveConfig.js";
+import {
+  buildAliasMap,
+  discoverComposeContract,
+  renderEnvContent,
+} from "../providers/docker-compose-contract.js";
 
 export interface SetupOptions {
   preset?: PresetName;
   dryRun?: boolean;
   refreshEnv?: boolean;
+  debug?: boolean;
   yes?: boolean;
   reset?: boolean;
+}
+
+function debugLog(enabled: boolean | undefined, message: string): void {
+  if (!enabled) return;
+  console.log(chalk.gray(`  [debug] ${message}`));
 }
 
 function printDetectionSummary(
@@ -140,17 +151,51 @@ async function resolveCurrentBranch(repoPath: string): Promise<string> {
 async function regenerateEnvFromConfig(
   repoPath: string,
   config: GroveConfig,
+  debug?: boolean,
 ): Promise<void> {
   const branch = await resolveCurrentBranch(repoPath);
   const envPath = path.join(repoPath, ".env.worktree");
+  debugLog(debug, `branch resolved as: ${branch}`);
   const expanded = expandNaming(config, branch);
-  const envContent = await buildEnvAgent(expanded);
+  const canonicalEnv = await buildCanonicalEnvVars(expanded);
+  const contract = await discoverComposeContract(repoPath);
+  const aliasEnv = buildAliasMap(contract, canonicalEnv);
+  const envContent = renderEnvContent(canonicalEnv, aliasEnv);
+  debugLog(
+    debug,
+    `contract expected vars: ${contract.expectedVars.length > 0 ? contract.expectedVars.join(", ") : "(none)"}`,
+  );
+  debugLog(
+    debug,
+    `contract port refs: ${contract.portRefs.length > 0 ? contract.portRefs.map((r) => `${r.service ?? "?"}:${r.variable}`).join(", ") : "(none)"}`,
+  );
+  debugLog(
+    debug,
+    `contract db refs: ${contract.dbNameRefs.length > 0 ? contract.dbNameRefs.map((r) => `${r.service ?? "?"}:${r.variable}`).join(", ") : "(none)"}`,
+  );
+  debugLog(
+    debug,
+    `canonical env vars: ${Object.keys(canonicalEnv)
+      .sort((a, b) => a.localeCompare(b))
+      .join(", ")}`,
+  );
   await writeFile(envPath, envContent, "utf-8");
 
   console.log(chalk.green("✓ Regenerated .env.worktree"));
   console.log(chalk.gray(`  branch: ${branch}`));
+  const aliasKeys = Object.keys(aliasEnv).sort((a, b) => a.localeCompare(b));
+  console.log(
+    chalk.gray(
+      `  aliases: ${aliasKeys.length > 0 ? aliasKeys.join(", ") : "none"}`,
+    ),
+  );
   for (const line of envContent.trim().split("\n")) {
     console.log(chalk.gray(`  ${line}`));
+  }
+  for (const warning of contract.warnings) {
+    console.log(
+      chalk.yellow(`  warning: compose contract detection: ${warning}`),
+    );
   }
 }
 
@@ -182,13 +227,41 @@ export async function runSetup(
       return;
     }
 
-    await regenerateEnvFromConfig(repoPath, existing);
+    await regenerateEnvFromConfig(repoPath, existing, opts.debug);
     return;
   }
 
   // 1. Detect project
   const detection = await detectProject(repoPath);
+  debugLog(
+    opts.debug,
+    `detected compose services: ${detection.composeServices.join(", ") || "(none)"}`,
+  );
+  debugLog(
+    opts.debug,
+    `detected app services: ${detection.appServices.join(", ") || "(none)"}`,
+  );
+  debugLog(
+    opts.debug,
+    `detected shared services: ${detection.sharedServices.join(", ") || "(none)"}`,
+  );
   printDetectionSummary(repoPath, detection);
+
+  if (opts.debug) {
+    const contract = await discoverComposeContract(repoPath);
+    debugLog(
+      true,
+      `contract expected vars: ${contract.expectedVars.join(", ") || "(none)"}`,
+    );
+    debugLog(
+      true,
+      `contract port refs: ${contract.portRefs.length > 0 ? contract.portRefs.map((r) => `${r.service ?? "?"}:${r.variable}`).join(", ") : "(none)"}`,
+    );
+    debugLog(
+      true,
+      `contract db refs: ${contract.dbNameRefs.length > 0 ? contract.dbNameRefs.map((r) => `${r.service ?? "?"}:${r.variable}`).join(", ") : "(none)"}`,
+    );
+  }
 
   // 2. Choose preset
   const presetName: PresetName = opts.preset ?? recommendPreset(detection);
@@ -253,6 +326,6 @@ export async function runSetup(
   console.log();
 
   if (opts.refreshEnv) {
-    await regenerateEnvFromConfig(repoPath, config);
+    await regenerateEnvFromConfig(repoPath, config, opts.debug);
   }
 }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -11,8 +11,10 @@ import { expandNaming, buildCanonicalEnvVars } from "../setup/naming.js";
 import { execa } from "execa";
 import { loadGroveConfig } from "../data/groveConfig.js";
 import {
-  buildAliasMap,
   discoverComposeContract,
+  readEnvFile,
+  readSourceEnvFiles,
+  resolveContractEnvVars,
   renderEnvContent,
 } from "../providers/docker-compose-contract.js";
 
@@ -156,11 +158,41 @@ async function regenerateEnvFromConfig(
   const branch = await resolveCurrentBranch(repoPath);
   const envPath = path.join(repoPath, ".env.worktree");
   debugLog(debug, `branch resolved as: ${branch}`);
+
+  const existingEnv = await readEnvFile(repoPath);
+  const existingWebPort = /^\d+$/.test(existingEnv["WEB_PORT"] ?? "")
+    ? Number.parseInt(existingEnv["WEB_PORT"], 10)
+    : undefined;
   const expanded = expandNaming(config, branch);
-  const canonicalEnv = await buildCanonicalEnvVars(expanded);
+  const canonicalEnv = await buildCanonicalEnvVars(expanded, existingWebPort);
   const contract = await discoverComposeContract(repoPath);
-  const aliasEnv = buildAliasMap(contract, canonicalEnv);
-  const envContent = renderEnvContent(canonicalEnv, aliasEnv);
+  const sourceEnv = {
+    ...(await readSourceEnvFiles(
+      repoPath,
+      config.envContract?.sourceEnvFiles ?? [".env"],
+    )),
+    ...existingEnv,
+  };
+  const contractEnv = resolveContractEnvVars(
+    contract,
+    canonicalEnv,
+    sourceEnv,
+    config.envContract,
+  );
+  const envErrors = contractEnv.issues.filter((i) => i.severity === "error");
+  if (envErrors.length > 0) {
+    throw new Error(
+      [
+        "Env contract resolution failed:",
+        ...envErrors.map((issue) =>
+          issue.details
+            ? `- ${issue.message} (${issue.details})`
+            : `- ${issue.message}`,
+        ),
+      ].join("\n"),
+    );
+  }
+  const envContent = renderEnvContent(canonicalEnv, contractEnv.values);
   debugLog(
     debug,
     `contract expected vars: ${contract.expectedVars.length > 0 ? contract.expectedVars.join(", ") : "(none)"}`,
@@ -183,7 +215,9 @@ async function regenerateEnvFromConfig(
 
   console.log(chalk.green("✓ Regenerated .env.worktree"));
   console.log(chalk.gray(`  branch: ${branch}`));
-  const aliasKeys = Object.keys(aliasEnv).sort((a, b) => a.localeCompare(b));
+  const aliasKeys = Object.keys(contractEnv.values).sort((a, b) =>
+    a.localeCompare(b),
+  );
   console.log(
     chalk.gray(
       `  aliases: ${aliasKeys.length > 0 ? aliasKeys.join(", ") : "none"}`,
@@ -196,6 +230,12 @@ async function regenerateEnvFromConfig(
     console.log(
       chalk.yellow(`  warning: compose contract detection: ${warning}`),
     );
+  }
+  for (const issue of contractEnv.issues.filter(
+    (i) => i.severity === "warning",
+  )) {
+    console.log(chalk.yellow(`  warning: env contract: ${issue.message}`));
+    if (issue.details) console.log(chalk.gray(`    ${issue.details}`));
   }
 }
 

--- a/src/data/groveConfig.test.ts
+++ b/src/data/groveConfig.test.ts
@@ -56,7 +56,7 @@ describe("loadGroveConfig", () => {
         web: { type: "docker-compose", service: "web" },
       },
       naming: {
-        composeProject: "grove-${branch_safe}",
+        composeProject: "${project}-${branch_safe}",
         dbSchema: "my_project_${branch_safe}",
         webPort: "auto",
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,18 @@ import {
   DEFAULT_SHARED_COMPOSE_FILE,
 } from "./providers/shared.js";
 import { loadGroveConfig } from "./data/groveConfig.js";
-import { expandNaming, buildEnvAgent } from "./setup/naming.js";
+import { expandNaming } from "./setup/naming.js";
 import { runSetup } from "./commands/setup.js";
 import { warnIfNotGitignored } from "./utils/gitignoreCheck.js";
 import { warnIfHardcodedComposePorts } from "./utils/hardcodedPortsCheck.js";
+import {
+  buildAliasMap,
+  discoverComposeContract,
+  formatDoctorEnvReport,
+  preflightComposeEnv,
+  readEnvFile,
+  renderEnvContent,
+} from "./providers/docker-compose-contract.js";
 import type { PresetName } from "./setup/presets.js";
 
 const pkg = { name: "grove-wt", version: "0.1.0" };
@@ -155,7 +163,10 @@ program
     "--new",
     "Create a new branch (use --base to set the starting point, defaults to main)",
   )
-  .option("--base <branch>", "Base branch for --new (default: main)")
+  .option(
+    "--base <branch>",
+    "Base branch for --new (default: .grove worktrees.defaultBaseBranch or main)",
+  )
   .option(
     "--refresh-env",
     "Regenerate .env.worktree from grove config before starting",
@@ -175,6 +186,7 @@ program
       const { existsSync } = await import("fs");
       const { writeFile } = await import("fs/promises");
       const pathMod = await import("path");
+      const { buildCanonicalEnvVars } = await import("./setup/naming.js");
       try {
         const repoPath = await detectRepoRoot();
         const repoGroveConfig = await loadGroveConfig(repoPath);
@@ -213,7 +225,10 @@ program
         if (!existsSync(worktreePath)) {
           if (!opts.json) console.log(`Creating worktree at ${worktreePath}…`);
           if (opts.new) {
-            const base = opts.base ?? "main";
+            const base =
+              opts.base ??
+              repoGroveConfig?.worktrees?.defaultBaseBranch ??
+              "main";
             if (!opts.json) console.log(`  branching off ${base}`);
             await execa(
               "git",
@@ -262,11 +277,29 @@ program
               );
             }
             const expanded = expandNaming(groveConfig, branch);
-            const envContent = await buildEnvAgent(expanded);
+            const canonicalEnv = await buildCanonicalEnvVars(expanded);
+            const contract = await discoverComposeContract(worktreePath);
+            const aliasEnv = buildAliasMap(contract, canonicalEnv);
+            const envContent = renderEnvContent(canonicalEnv, aliasEnv);
             await writeFile(envAgentPath, envContent, "utf-8");
             if (!opts.json) {
+              const aliasKeys = Object.keys(aliasEnv).sort((a, b) =>
+                a.localeCompare(b),
+              );
+              console.log(
+                chalk.gray(
+                  `  aliases: ${aliasKeys.length > 0 ? aliasKeys.join(", ") : "none"}`,
+                ),
+              );
               for (const line of envContent.trim().split("\n")) {
                 console.log(chalk.gray(`  ${line}`));
+              }
+              for (const warning of contract.warnings) {
+                console.log(
+                  chalk.yellow(
+                    `  warning: compose contract detection: ${warning}`,
+                  ),
+                );
               }
             }
           }
@@ -364,9 +397,16 @@ const docker = program
 docker
   .command("up [branch]")
   .description("Start docker compose stack for a worktree")
-  .action(async (branch?: string) => {
+  .option("--debug", "Enable debug output")
+  .action(async (branch: string | undefined, opts: { debug?: boolean }) => {
     const { execa } = await import("execa");
     try {
+      const debug = Boolean(opts.debug || process.env.GROVE_DEBUG === "1");
+      const logDebug = (message: string) => {
+        if (!debug) return;
+        console.log(chalk.gray(`  [debug] ${message}`));
+      };
+
       const repoPath = await detectRepoRoot();
       const config = await loadGroveConfig(repoPath);
       await warnIfHardcodedComposePorts(repoPath, [
@@ -386,22 +426,48 @@ docker
         console.error(`No .env.worktree found in ${wt.path}`);
         process.exit(1);
       }
+
+      const contract = await discoverComposeContract(wt.path);
+      const envVars = await readEnvFile(wt.path);
+      logDebug(
+        `compose expected vars: ${contract.expectedVars.join(", ") || "(none)"}`,
+      );
+      logDebug(
+        `compose port refs: ${contract.portRefs.length > 0 ? contract.portRefs.map((r) => `${r.service ?? "?"}:${r.variable}`).join(", ") : "(none)"}`,
+      );
+      const preflight = await preflightComposeEnv(wt.path, contract, envVars);
+      if (!preflight.ok) {
+        console.error("Compose env preflight failed:");
+        for (const issue of preflight.issues) {
+          console.error(`- ${issue.message}`);
+          if (issue.details) console.error(`  ${issue.details}`);
+          if (issue.suggestion) console.error(`  fix: ${issue.suggestion}`);
+        }
+        process.exit(1);
+      }
+
+      for (const issue of preflight.issues.filter(
+        (i) => i.severity === "warning",
+      )) {
+        console.warn(`warning: ${issue.message}`);
+        if (issue.details) console.warn(`  ${issue.details}`);
+      }
+
       const { projectName } = wt.docker;
       console.log(`Starting ${projectName}…`);
-      await execa(
-        "docker",
-        [
-          "compose",
-          "-p",
-          projectName,
-          "--env-file",
-          ".env.worktree",
-          "up",
-          "-d",
-          "--build",
-        ],
-        { cwd: wt.path },
-      );
+      const composeArgs = [
+        "compose",
+        "-p",
+        projectName,
+        "--env-file",
+        ".env.worktree",
+        "up",
+        "-d",
+        "--build",
+      ];
+      logDebug(`running in ${wt.path}`);
+      logDebug(`docker ${composeArgs.join(" ")}`);
+      await execa("docker", composeArgs, { cwd: wt.path });
       console.log(`✓ ${projectName} started`);
     } catch (err) {
       console.error((err as Error).message);
@@ -783,6 +849,7 @@ program
     "--refresh-env",
     "Regenerate .env.worktree in the current worktree from grove config",
   )
+  .option("--debug", "Enable debug output")
   .option("--yes", "Skip confirmation prompt")
   .option("--reset", "Overwrite existing .grove/config.json")
   .action(
@@ -790,6 +857,7 @@ program
       preset?: string;
       dryRun?: boolean;
       refreshEnv?: boolean;
+      debug?: boolean;
       yes?: boolean;
       reset?: boolean;
     }) => {
@@ -799,6 +867,7 @@ program
           preset: opts.preset as PresetName | undefined,
           dryRun: opts.dryRun,
           refreshEnv: opts.refreshEnv,
+          debug: opts.debug,
           yes: opts.yes,
           reset: opts.reset,
         });
@@ -808,6 +877,37 @@ program
       }
     },
   );
+
+const doctor = program.command("doctor").description("Run Grove diagnostics");
+
+doctor
+  .command("env [branch]")
+  .description("Inspect compose env contract, aliases, and resolved host ports")
+  .action(async (branch?: string) => {
+    try {
+      const repoPath = await detectRepoRoot();
+      const { worktrees } = await loadWorktrees(repoPath);
+      const wt = branch
+        ? worktrees.find(
+            (w) => w.branch === branch || w.branch.endsWith(`/${branch}`),
+          )
+        : worktrees[0];
+      if (!wt) {
+        console.error("No worktree found");
+        process.exit(1);
+      }
+
+      const contract = await discoverComposeContract(wt.path);
+      const envVars = await readEnvFile(wt.path);
+      const preflight = await preflightComposeEnv(wt.path, contract, envVars);
+
+      console.log(formatDoctorEnvReport(contract, envVars, preflight));
+      if (!preflight.ok) process.exit(1);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
 
 // Default: TUI mode (no subcommand)
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,11 +156,20 @@ program
     "Create a new branch (use --base to set the starting point, defaults to main)",
   )
   .option("--base <branch>", "Base branch for --new (default: main)")
+  .option(
+    "--refresh-env",
+    "Regenerate .env.worktree from grove config before starting",
+  )
   .option("--json", "Output machine-readable JSON")
   .action(
     async (
       target: string,
-      opts: { new?: boolean; base?: string; json?: boolean },
+      opts: {
+        new?: boolean;
+        base?: string;
+        refreshEnv?: boolean;
+        json?: boolean;
+      },
     ) => {
       const { execa } = await import("execa");
       const { existsSync } = await import("fs");
@@ -229,21 +238,36 @@ program
           console.log(`Attaching to existing worktree at ${worktreePath}…`);
         }
 
-        // 2. Generate .env.worktree from grove config naming templates if not present
+        // 2. Generate .env.worktree from grove config naming templates
         const envAgentPath = pathMod.join(worktreePath, ".env.worktree");
         const groveConfig =
           (await loadGroveConfig(worktreePath)) ??
           (await loadGroveConfig(repoPath));
-        if (!existsSync(envAgentPath)) {
-          if (groveConfig) {
-            if (!opts.json)
-              console.log("Generating .env.worktree from grove config…");
+        const shouldGenerateEnv = !existsSync(envAgentPath) || opts.refreshEnv;
+        if (shouldGenerateEnv) {
+          if (!groveConfig) {
+            if (!opts.json && opts.refreshEnv) {
+              console.log(
+                chalk.yellow(
+                  "  warning: --refresh-env requested but no .grove/config.json was found",
+                ),
+              );
+            }
+          } else {
+            if (!opts.json) {
+              console.log(
+                opts.refreshEnv
+                  ? "Regenerating .env.worktree from grove config…"
+                  : "Generating .env.worktree from grove config…",
+              );
+            }
             const expanded = expandNaming(groveConfig, branch);
             const envContent = await buildEnvAgent(expanded);
             await writeFile(envAgentPath, envContent, "utf-8");
             if (!opts.json) {
-              for (const line of envContent.trim().split("\n"))
+              for (const line of envContent.trim().split("\n")) {
                 console.log(chalk.gray(`  ${line}`));
+              }
             }
           }
         }
@@ -755,12 +779,17 @@ program
   .description("Detect project type and write .grove/config.json")
   .option("--preset <name>", "Use a specific preset (docker, vite, node)")
   .option("--dry-run", "Print proposed config without writing anything")
+  .option(
+    "--refresh-env",
+    "Regenerate .env.worktree in the current worktree from grove config",
+  )
   .option("--yes", "Skip confirmation prompt")
   .option("--reset", "Overwrite existing .grove/config.json")
   .action(
     async (opts: {
       preset?: string;
       dryRun?: boolean;
+      refreshEnv?: boolean;
       yes?: boolean;
       reset?: boolean;
     }) => {
@@ -769,6 +798,7 @@ program
         await runSetup(repoPath, {
           preset: opts.preset as PresetName | undefined,
           dryRun: opts.dryRun,
+          refreshEnv: opts.refreshEnv,
           yes: opts.yes,
           reset: opts.reset,
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { loadGroveConfig } from "./data/groveConfig.js";
 import { expandNaming, buildEnvAgent } from "./setup/naming.js";
 import { runSetup } from "./commands/setup.js";
 import { warnIfNotGitignored } from "./utils/gitignoreCheck.js";
+import { warnIfHardcodedComposePorts } from "./utils/hardcodedPortsCheck.js";
 import type { PresetName } from "./setup/presets.js";
 
 const pkg = { name: "grove-wt", version: "0.1.0" };
@@ -168,6 +169,9 @@ program
       try {
         const repoPath = await detectRepoRoot();
         const repoGroveConfig = await loadGroveConfig(repoPath);
+        await warnIfHardcodedComposePorts(repoPath, [
+          repoGroveConfig?.sharedComposeFile ?? DEFAULT_SHARED_COMPOSE_FILE,
+        ]);
         const worktreeRoot = resolveWorktreeRoot(
           repoPath,
           repoGroveConfig?.worktrees?.root,
@@ -340,6 +344,10 @@ docker
     const { execa } = await import("execa");
     try {
       const repoPath = await detectRepoRoot();
+      const config = await loadGroveConfig(repoPath);
+      await warnIfHardcodedComposePorts(repoPath, [
+        config?.sharedComposeFile ?? DEFAULT_SHARED_COMPOSE_FILE,
+      ]);
       const { worktrees } = await loadWorktrees(repoPath);
       const wt = branch
         ? worktrees.find(
@@ -491,6 +499,9 @@ shared
     try {
       const repoPath = await detectRepoRoot();
       const config = await loadGroveConfig(repoPath);
+      await warnIfHardcodedComposePorts(repoPath, [
+        config?.sharedComposeFile ?? DEFAULT_SHARED_COMPOSE_FILE,
+      ]);
       const info = resolveSharedStack(repoPath, config);
       if (!info) {
         console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,11 +25,12 @@ import { runSetup } from "./commands/setup.js";
 import { warnIfNotGitignored } from "./utils/gitignoreCheck.js";
 import { warnIfHardcodedComposePorts } from "./utils/hardcodedPortsCheck.js";
 import {
-  buildAliasMap,
   discoverComposeContract,
   formatDoctorEnvReport,
   preflightComposeEnv,
   readEnvFile,
+  readSourceEnvFiles,
+  resolveContractEnvVars,
   renderEnvContent,
 } from "./providers/docker-compose-contract.js";
 import type { PresetName } from "./setup/presets.js";
@@ -276,14 +277,51 @@ program
                   : "Generating .env.worktree from grove config…",
               );
             }
+            const existingEnv = await readEnvFile(worktreePath);
+            const existingWebPort = /^\d+$/.test(existingEnv["WEB_PORT"] ?? "")
+              ? Number.parseInt(existingEnv["WEB_PORT"], 10)
+              : undefined;
             const expanded = expandNaming(groveConfig, branch);
-            const canonicalEnv = await buildCanonicalEnvVars(expanded);
+            const canonicalEnv = await buildCanonicalEnvVars(
+              expanded,
+              existingWebPort,
+            );
             const contract = await discoverComposeContract(worktreePath);
-            const aliasEnv = buildAliasMap(contract, canonicalEnv);
-            const envContent = renderEnvContent(canonicalEnv, aliasEnv);
+            const sourceEnv = {
+              ...(await readSourceEnvFiles(
+                worktreePath,
+                groveConfig.envContract?.sourceEnvFiles ?? [".env"],
+              )),
+              ...existingEnv,
+            };
+            const contractEnv = resolveContractEnvVars(
+              contract,
+              canonicalEnv,
+              sourceEnv,
+              groveConfig.envContract,
+            );
+            const envErrors = contractEnv.issues.filter(
+              (issue) => issue.severity === "error",
+            );
+            if (envErrors.length > 0) {
+              throw new Error(
+                [
+                  "Env contract resolution failed:",
+                  ...envErrors.map((issue) =>
+                    issue.details
+                      ? `- ${issue.message} (${issue.details})`
+                      : `- ${issue.message}`,
+                  ),
+                ].join("\n"),
+              );
+            }
+            const envContent = renderEnvContent(
+              canonicalEnv,
+              contractEnv.values,
+            );
             await writeFile(envAgentPath, envContent, "utf-8");
             if (!opts.json) {
-              const aliasKeys = Object.keys(aliasEnv).sort((a, b) =>
+              const aliasKeys = Object.keys(contractEnv.values).sort((a, b) =>
                 a.localeCompare(b),
               );
               console.log(
@@ -300,6 +338,15 @@ program
                     `  warning: compose contract detection: ${warning}`,
                   ),
                 );
+              }
+              for (const issue of contractEnv.issues.filter(
+                (issue) => issue.severity === "warning",
+              )) {
+                console.log(
+                  chalk.yellow(`  warning: env contract: ${issue.message}`),
+                );
+                if (issue.details)
+                  console.log(chalk.gray(`    ${issue.details}`));
               }
             }
           }
@@ -435,7 +482,12 @@ docker
       logDebug(
         `compose port refs: ${contract.portRefs.length > 0 ? contract.portRefs.map((r) => `${r.service ?? "?"}:${r.variable}`).join(", ") : "(none)"}`,
       );
-      const preflight = await preflightComposeEnv(wt.path, contract, envVars);
+      const preflight = await preflightComposeEnv(
+        wt.path,
+        contract,
+        envVars,
+        config?.envContract,
+      );
       if (!preflight.ok) {
         console.error("Compose env preflight failed:");
         for (const issue of preflight.issues) {
@@ -899,7 +951,14 @@ doctor
 
       const contract = await discoverComposeContract(wt.path);
       const envVars = await readEnvFile(wt.path);
-      const preflight = await preflightComposeEnv(wt.path, contract, envVars);
+      const wtConfig =
+        (await loadGroveConfig(wt.path)) ?? (await loadGroveConfig(repoPath));
+      const preflight = await preflightComposeEnv(
+        wt.path,
+        contract,
+        envVars,
+        wtConfig?.envContract,
+      );
 
       console.log(formatDoctorEnvReport(contract, envVars, preflight));
       if (!preflight.ok) process.exit(1);

--- a/src/providers/docker-compose-contract.test.ts
+++ b/src/providers/docker-compose-contract.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+import {
+  analyzeResolvedPorts,
+  buildAliasMap,
+  discoverComposeContractFromText,
+  extractInterpolationVars,
+  renderEnvContent,
+} from "./docker-compose-contract.js";
+
+describe("extractInterpolationVars", () => {
+  test("extracts nested fallback variables", () => {
+    const vars = extractInterpolationVars("${APP_PORT:-${API_PORT:-3000}}");
+    expect(vars).toEqual(expect.arrayContaining(["APP_PORT", "API_PORT"]));
+  });
+});
+
+describe("discoverComposeContractFromText", () => {
+  test("discovers APP/POSTGRES vars from compose fixture", () => {
+    const compose = `
+services:
+  app:
+    image: node:20
+    ports:
+      - "\${APP_PORT:-3000}:3000"
+    environment:
+      DATABASE_URL: postgres://postgres:dev@db:\${POSTGRES_PORT:-5432}/\${POSTGRES_DB:-app}
+  db:
+    image: postgres:16
+    ports:
+      - "\${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: \${POSTGRES_DB:-app}
+`;
+
+    const contract = discoverComposeContractFromText(compose);
+
+    expect(contract.expectedVars).toEqual(
+      expect.arrayContaining(["APP_PORT", "POSTGRES_PORT", "POSTGRES_DB"]),
+    );
+
+    expect(contract.portRefs.map((r) => r.variable)).toEqual(
+      expect.arrayContaining(["APP_PORT", "POSTGRES_PORT"]),
+    );
+
+    expect(contract.dbNameRefs.map((r) => r.variable)).toEqual(
+      expect.arrayContaining(["POSTGRES_DB"]),
+    );
+  });
+
+  test("discovers canonical grove vars from compose fixture", () => {
+    const compose = `
+services:
+  web:
+    image: app
+    ports:
+      - "\${WEB_PORT}:3000"
+    environment:
+      DB_SCHEMA: \${DB_SCHEMA}
+  db:
+    image: postgres
+    ports:
+      - "\${DB_PORT}:5432"
+`;
+
+    const contract = discoverComposeContractFromText(compose);
+
+    expect(contract.expectedVars).toEqual(
+      expect.arrayContaining(["WEB_PORT", "DB_PORT", "DB_SCHEMA"]),
+    );
+  });
+});
+
+describe("buildAliasMap", () => {
+  test("maps discovered aliases to canonical values", () => {
+    const contract = discoverComposeContractFromText(`
+services:
+  app:
+    ports:
+      - "\${APP_PORT:-3000}:3000"
+  db:
+    ports:
+      - "\${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: \${POSTGRES_DB:-app}
+`);
+
+    const canonical = {
+      COMPOSE_PROJECT_NAME: "grove-branch",
+      WEB_PORT: "8088",
+      API_PORT: "8089",
+      DB_PORT: "15432",
+      DB_SCHEMA: "myapp_branch",
+    };
+
+    const aliases = buildAliasMap(contract, canonical);
+
+    expect(aliases["APP_PORT"]).toBe("8088");
+    expect(aliases["POSTGRES_PORT"]).toBe("15432");
+    expect(aliases["POSTGRES_DB"]).toBe("myapp_branch");
+  });
+});
+
+describe("renderEnvContent", () => {
+  test("keeps canonical keys and appends aliases deterministically", () => {
+    const content = renderEnvContent(
+      {
+        COMPOSE_PROJECT_NAME: "grove-foo",
+        WEB_PORT: "8080",
+        API_PORT: "8081",
+        DB_PORT: "15432",
+        DB_SCHEMA: "myapp_foo",
+      },
+      {
+        APP_PORT: "8080",
+        POSTGRES_DB: "myapp_foo",
+        POSTGRES_PORT: "15432",
+      },
+    );
+
+    const lines = content.trim().split("\n");
+    expect(lines[0]).toBe("COMPOSE_PROJECT_NAME=grove-foo");
+    expect(lines).toContain("APP_PORT=8080");
+    expect(lines).toContain("POSTGRES_PORT=15432");
+    expect(lines).toContain("POSTGRES_DB=myapp_foo");
+  });
+});
+
+describe("analyzeResolvedPorts", () => {
+  test("flags collisions and default fallback mismatches", () => {
+    const issues = analyzeResolvedPorts(
+      [
+        { service: "app", hostPort: 3000, targetPort: 3000 },
+        { service: "db", hostPort: 15432, targetPort: 5432 },
+      ],
+      {
+        WEB_PORT: "8088",
+        API_PORT: "8089",
+        DB_PORT: "15432",
+      },
+      new Set([15432]),
+    );
+
+    expect(issues.some((i) => i.message.includes("collision"))).toBe(true);
+    expect(
+      issues.some((i) => i.message.includes("default-looking host port 3000")),
+    ).toBe(true);
+  });
+});

--- a/src/providers/docker-compose-contract.test.ts
+++ b/src/providers/docker-compose-contract.test.ts
@@ -6,6 +6,7 @@ import {
   extractInterpolationVars,
   formatDoctorEnvReport,
   preflightComposeEnv,
+  resolveContractEnvVars,
   renderEnvContent,
 } from "./docker-compose-contract.js";
 
@@ -73,7 +74,7 @@ services:
 });
 
 describe("buildAliasMap", () => {
-  test("maps discovered aliases to canonical values", () => {
+  test("maps discovered port aliases to canonical values", () => {
     const contract = discoverComposeContractFromText(`
 services:
   app:
@@ -98,7 +99,76 @@ services:
 
     expect(aliases["APP_PORT"]).toBe("8088");
     expect(aliases["POSTGRES_PORT"]).toBe("15432");
-    expect(aliases["POSTGRES_DB"]).toBe("myapp_branch");
+    expect(aliases["POSTGRES_DB"]).toBeUndefined();
+  });
+});
+
+describe("resolveContractEnvVars", () => {
+  test("supports derived and passthrough vars from explicit env contract", () => {
+    const contract = discoverComposeContractFromText(`
+services:
+  app:
+    environment:
+      DATABASE_URL: \${DATABASE_URL}
+      FEATURE_FLAG: \${FEATURE_FLAG}
+`);
+
+    const result = resolveContractEnvVars(
+      contract,
+      {
+        COMPOSE_PROJECT_NAME: "grove-branch",
+        WEB_PORT: "8088",
+        API_PORT: "8089",
+        DB_PORT: "15432",
+        DB_SCHEMA: "myapp_branch",
+      },
+      {
+        POSTGRES_USER: "postgres",
+        POSTGRES_PASSWORD: "dev",
+        POSTGRES_DB: "app",
+        FEATURE_FLAG: "on",
+      },
+      {
+        derived: {
+          DATABASE_URL:
+            "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@cooh-db:5432/${POSTGRES_DB}?schema=${DB_SCHEMA}",
+        },
+        passthrough: ["FEATURE_FLAG"],
+      },
+    );
+
+    expect(result.values["DATABASE_URL"]).toContain("schema=myapp_branch");
+    expect(result.values["FEATURE_FLAG"]).toBe("on");
+    expect(result.issues).toHaveLength(0);
+  });
+
+  test("in strict mode unresolved expected vars are errors", () => {
+    const contract = discoverComposeContractFromText(`
+services:
+  app:
+    environment:
+      DATABASE_URL: \${DATABASE_URL}
+`);
+
+    const result = resolveContractEnvVars(
+      contract,
+      {
+        COMPOSE_PROJECT_NAME: "grove-branch",
+        WEB_PORT: "8088",
+        API_PORT: "8089",
+        DB_PORT: "15432",
+        DB_SCHEMA: "myapp_branch",
+      },
+      {},
+      {
+        strict: true,
+      },
+    );
+
+    expect(result.issues.some((issue) => issue.severity === "error")).toBe(
+      true,
+    );
+    expect(result.values["DATABASE_URL"]).toBeUndefined();
   });
 });
 
@@ -150,7 +220,7 @@ describe("analyzeResolvedPorts", () => {
 });
 
 describe("preflightComposeEnv", () => {
-  test("treats expectedVars as required compose variables", async () => {
+  test("requires expectedVars in strict mode", async () => {
     const result = await preflightComposeEnv(
       process.cwd(),
       {
@@ -161,6 +231,7 @@ describe("preflightComposeEnv", () => {
         warnings: [],
       },
       {},
+      { strict: true },
     );
 
     expect(

--- a/src/providers/docker-compose-contract.test.ts
+++ b/src/providers/docker-compose-contract.test.ts
@@ -4,6 +4,8 @@ import {
   buildAliasMap,
   discoverComposeContractFromText,
   extractInterpolationVars,
+  formatDoctorEnvReport,
+  preflightComposeEnv,
   renderEnvContent,
 } from "./docker-compose-contract.js";
 
@@ -144,5 +146,73 @@ describe("analyzeResolvedPorts", () => {
     expect(
       issues.some((i) => i.message.includes("default-looking host port 3000")),
     ).toBe(true);
+  });
+});
+
+describe("preflightComposeEnv", () => {
+  test("treats expectedVars as required compose variables", async () => {
+    const result = await preflightComposeEnv(
+      process.cwd(),
+      {
+        expectedVars: ["FEATURE_FLAG"],
+        portRefs: [],
+        dbNameRefs: [],
+        projectNameVars: [],
+        warnings: [],
+      },
+      {},
+    );
+
+    expect(
+      result.issues.some((issue) =>
+        issue.message.includes(
+          "Missing required compose variable: FEATURE_FLAG",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("treats empty-string env values as present", async () => {
+    const result = await preflightComposeEnv(
+      process.cwd(),
+      {
+        expectedVars: ["FEATURE_FLAG"],
+        portRefs: [],
+        dbNameRefs: [],
+        projectNameVars: [],
+        warnings: [],
+      },
+      { FEATURE_FLAG: "" },
+    );
+
+    expect(
+      result.issues.some((issue) =>
+        issue.message.includes(
+          "Missing required compose variable: FEATURE_FLAG",
+        ),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("formatDoctorEnvReport", () => {
+  test("does not list empty-string expected vars as missing", () => {
+    const report = formatDoctorEnvReport(
+      {
+        expectedVars: ["FEATURE_FLAG"],
+        portRefs: [],
+        dbNameRefs: [],
+        projectNameVars: [],
+        warnings: [],
+      },
+      { FEATURE_FLAG: "" },
+      {
+        ok: true,
+        issues: [],
+        resolvedPublishedPorts: [],
+      },
+    );
+
+    expect(report).toContain("Missing vars:\n  (none)");
   });
 });

--- a/src/providers/docker-compose-contract.ts
+++ b/src/providers/docker-compose-contract.ts
@@ -1,0 +1,809 @@
+import { execa } from "execa";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+
+const COMPOSE_FILES = [
+  "compose.yaml",
+  "compose.yml",
+  "docker-compose.yml",
+  "docker-compose.yaml",
+];
+
+const INTERPOLATION_RE = /\$\{([A-Z][A-Z0-9_]*)/g;
+const PUBLISHED_PORT_RE =
+  /(?:^|[\s,])(?:[^\s:,]+:)?(\d{2,5})->\d{2,5}\/(?:tcp|udp)/g;
+
+export interface ComposePortRef {
+  variable: string;
+  service?: string;
+  source: "ports" | "variables" | "text-scan";
+}
+
+export interface ComposeDbNameRef {
+  variable: string;
+  service?: string;
+  source: "environment" | "variables" | "text-scan";
+}
+
+export interface ComposeContract {
+  expectedVars: string[];
+  portRefs: ComposePortRef[];
+  dbNameRefs: ComposeDbNameRef[];
+  projectNameVars: string[];
+  warnings: string[];
+}
+
+export interface PreflightIssue {
+  severity: "error" | "warning";
+  message: string;
+  details?: string;
+  suggestion?: string;
+}
+
+export interface PreflightResult {
+  ok: boolean;
+  issues: PreflightIssue[];
+  resolvedPublishedPorts: Array<{
+    service: string;
+    hostPort: number;
+    targetPort?: number;
+  }>;
+}
+
+function uniqSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+export function extractInterpolationVars(input: string): string[] {
+  const vars = new Set<string>();
+  for (const match of input.matchAll(INTERPOLATION_RE)) {
+    vars.add(match[1]);
+  }
+  return [...vars];
+}
+
+function isDbLikeVar(variable: string): boolean {
+  return /(DB|DATABASE|POSTGRES|PG|SCHEMA)/i.test(variable);
+}
+
+function isDbNameLikeVar(variable: string): boolean {
+  if (!isDbLikeVar(variable)) return false;
+  if (/(PASSWORD|PASS|USER|USERNAME|URL|HOST|PORT)/i.test(variable)) {
+    return false;
+  }
+  return true;
+}
+
+function isPortLikeVar(variable: string): boolean {
+  return /PORT/i.test(variable);
+}
+
+function pushPortRef(
+  refs: ComposePortRef[],
+  variable: string,
+  service: string | undefined,
+  source: ComposePortRef["source"],
+): void {
+  refs.push({ variable, service, source });
+}
+
+function pushDbRef(
+  refs: ComposeDbNameRef[],
+  variable: string,
+  service: string | undefined,
+  source: ComposeDbNameRef["source"],
+): void {
+  refs.push({ variable, service, source });
+}
+
+function mergeContract(parts: ComposeContract[]): ComposeContract {
+  const expectedVars = new Set<string>();
+  const projectNameVars = new Set<string>();
+  const warnings: string[] = [];
+  const portRefs: ComposePortRef[] = [];
+  const dbNameRefs: ComposeDbNameRef[] = [];
+
+  for (const part of parts) {
+    for (const variable of part.expectedVars) expectedVars.add(variable);
+    for (const variable of part.projectNameVars) projectNameVars.add(variable);
+    portRefs.push(...part.portRefs);
+    dbNameRefs.push(...part.dbNameRefs);
+    warnings.push(...part.warnings);
+  }
+
+  const dedupeKey = (v: {
+    variable: string;
+    service?: string;
+    source: string;
+  }) => `${v.variable}|${v.service ?? ""}|${v.source}`;
+
+  return {
+    expectedVars: uniqSorted(expectedVars),
+    projectNameVars: uniqSorted(projectNameVars),
+    portRefs: Object.values(
+      Object.fromEntries(portRefs.map((ref) => [dedupeKey(ref), ref])),
+    ),
+    dbNameRefs: Object.values(
+      Object.fromEntries(dbNameRefs.map((ref) => [dedupeKey(ref), ref])),
+    ),
+    warnings,
+  };
+}
+
+export function discoverComposeContractFromText(raw: string): ComposeContract {
+  const expectedVars = new Set<string>();
+  const projectNameVars = new Set<string>();
+  const portRefs: ComposePortRef[] = [];
+  const dbNameRefs: ComposeDbNameRef[] = [];
+
+  let currentService: string | undefined;
+  let inPorts = false;
+  let inEnvironment = false;
+
+  const lines = raw.split("\n");
+
+  for (const line of lines) {
+    const serviceMatch = line.match(/^\s{2}([a-zA-Z0-9_.-]+):\s*$/);
+    if (serviceMatch) {
+      currentService = serviceMatch[1];
+      inPorts = false;
+      inEnvironment = false;
+      continue;
+    }
+
+    if (/^\s{4}ports:\s*$/.test(line)) {
+      inPorts = true;
+      inEnvironment = false;
+      continue;
+    }
+
+    if (/^\s{4}environment:\s*$/.test(line)) {
+      inEnvironment = true;
+      inPorts = false;
+      continue;
+    }
+
+    if (/^\s{0,3}\S/.test(line)) {
+      inPorts = false;
+      inEnvironment = false;
+    }
+
+    const vars = extractInterpolationVars(line);
+    for (const variable of vars) {
+      expectedVars.add(variable);
+      if (variable === "COMPOSE_PROJECT_NAME") {
+        projectNameVars.add(variable);
+      }
+      if (inPorts || isPortLikeVar(variable)) {
+        pushPortRef(portRefs, variable, currentService, "text-scan");
+      }
+      if (inEnvironment && isDbLikeVar(variable)) {
+        pushDbRef(dbNameRefs, variable, currentService, "text-scan");
+      }
+      if (inEnvironment && isDbNameLikeVar(variable)) {
+        pushDbRef(dbNameRefs, variable, currentService, "text-scan");
+      }
+    }
+
+    if (inEnvironment) {
+      const envKeyMatch = line.match(
+        /^\s*(?:-\s*)?([A-Z][A-Z0-9_]+)\s*(?:=|:)/,
+      );
+      if (envKeyMatch && isDbNameLikeVar(envKeyMatch[1])) {
+        expectedVars.add(envKeyMatch[1]);
+        pushDbRef(dbNameRefs, envKeyMatch[1], currentService, "text-scan");
+      }
+    }
+
+    if (/^\s*name:\s*\$\{/.test(line)) {
+      for (const variable of vars) {
+        if (variable === "COMPOSE_PROJECT_NAME") {
+          projectNameVars.add(variable);
+        }
+      }
+    }
+  }
+
+  return {
+    expectedVars: uniqSorted(expectedVars),
+    projectNameVars: uniqSorted(projectNameVars),
+    portRefs,
+    dbNameRefs,
+    warnings: [],
+  };
+}
+
+function discoverContractFromComposeModel(model: unknown): ComposeContract {
+  const expectedVars = new Set<string>();
+  const projectNameVars = new Set<string>();
+  const portRefs: ComposePortRef[] = [];
+  const dbNameRefs: ComposeDbNameRef[] = [];
+
+  const typed = model as Record<string, unknown>;
+
+  const maybeName = typed["name"];
+  if (typeof maybeName === "string") {
+    for (const variable of extractInterpolationVars(maybeName)) {
+      expectedVars.add(variable);
+      if (variable === "COMPOSE_PROJECT_NAME") projectNameVars.add(variable);
+    }
+  }
+
+  const services = typed["services"] as Record<string, unknown> | undefined;
+  if (!services || typeof services !== "object") {
+    return {
+      expectedVars: uniqSorted(expectedVars),
+      portRefs,
+      dbNameRefs,
+      projectNameVars: uniqSorted(projectNameVars),
+      warnings: [],
+    };
+  }
+
+  for (const [serviceName, serviceConfigUnknown] of Object.entries(services)) {
+    const serviceConfig = serviceConfigUnknown as Record<string, unknown>;
+
+    const ports = serviceConfig["ports"] as unknown[] | undefined;
+    if (Array.isArray(ports)) {
+      for (const entry of ports) {
+        if (typeof entry === "string") {
+          for (const variable of extractInterpolationVars(entry)) {
+            expectedVars.add(variable);
+            pushPortRef(portRefs, variable, serviceName, "ports");
+          }
+        } else if (entry && typeof entry === "object") {
+          const published = (entry as Record<string, unknown>)["published"];
+          if (typeof published === "string") {
+            for (const variable of extractInterpolationVars(published)) {
+              expectedVars.add(variable);
+              pushPortRef(portRefs, variable, serviceName, "ports");
+            }
+          }
+        }
+      }
+    }
+
+    const environment = serviceConfig["environment"];
+    if (Array.isArray(environment)) {
+      for (const item of environment) {
+        if (typeof item !== "string") continue;
+        const [key, ...rest] = item.split("=");
+        const value = rest.join("=");
+        if (key && isDbNameLikeVar(key)) {
+          expectedVars.add(key);
+          pushDbRef(dbNameRefs, key, serviceName, "environment");
+        }
+        for (const variable of extractInterpolationVars(value)) {
+          expectedVars.add(variable);
+          if (isDbNameLikeVar(variable) || isDbNameLikeVar(key)) {
+            pushDbRef(dbNameRefs, variable, serviceName, "environment");
+          }
+        }
+      }
+    } else if (environment && typeof environment === "object") {
+      for (const [key, value] of Object.entries(
+        environment as Record<string, unknown>,
+      )) {
+        if (isDbNameLikeVar(key)) {
+          expectedVars.add(key);
+          pushDbRef(dbNameRefs, key, serviceName, "environment");
+        }
+        if (typeof value === "string") {
+          for (const variable of extractInterpolationVars(value)) {
+            expectedVars.add(variable);
+            if (isDbNameLikeVar(variable) || isDbNameLikeVar(key)) {
+              pushDbRef(dbNameRefs, variable, serviceName, "environment");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    expectedVars: uniqSorted(expectedVars),
+    portRefs,
+    dbNameRefs,
+    projectNameVars: uniqSorted(projectNameVars),
+    warnings: [],
+  };
+}
+
+function parseVariablesOutput(raw: string): string[] {
+  const vars = new Set<string>();
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([A-Z][A-Z0-9_]+)/);
+    if (match) vars.add(match[1]);
+  }
+  return [...vars];
+}
+
+async function runComposeConfigNoInterpolate(
+  worktreePath: string,
+): Promise<{ contract?: ComposeContract; warning?: string }> {
+  try {
+    const { stdout } = await execa(
+      "docker",
+      ["compose", "config", "--no-interpolate", "--format", "json"],
+      {
+        cwd: worktreePath,
+      },
+    );
+
+    const parsed = JSON.parse(stdout) as unknown;
+    return { contract: discoverContractFromComposeModel(parsed) };
+  } catch (error) {
+    return {
+      warning: `docker compose config --no-interpolate unavailable: ${(error as Error).message}`,
+    };
+  }
+}
+
+async function runComposeVariables(
+  worktreePath: string,
+): Promise<{ expectedVars?: string[]; warning?: string }> {
+  try {
+    const { stdout } = await execa(
+      "docker",
+      ["compose", "config", "--variables"],
+      {
+        cwd: worktreePath,
+      },
+    );
+    return { expectedVars: parseVariablesOutput(stdout) };
+  } catch (error) {
+    return {
+      warning: `docker compose config --variables unavailable: ${(error as Error).message}`,
+    };
+  }
+}
+
+export async function discoverComposeContract(
+  worktreePath: string,
+): Promise<ComposeContract> {
+  const warnings: string[] = [];
+
+  const [modelResult, varsResult] = await Promise.all([
+    runComposeConfigNoInterpolate(worktreePath),
+    runComposeVariables(worktreePath),
+  ]);
+
+  if (modelResult.warning) warnings.push(modelResult.warning);
+  if (varsResult.warning) warnings.push(varsResult.warning);
+
+  const fileContracts: ComposeContract[] = [];
+  for (const composeFile of COMPOSE_FILES) {
+    const composePath = path.join(worktreePath, composeFile);
+    if (!existsSync(composePath)) continue;
+    const raw = await readFile(composePath, "utf-8");
+    fileContracts.push(discoverComposeContractFromText(raw));
+  }
+
+  if (fileContracts.length === 0 && !modelResult.contract) {
+    warnings.push("no compose files discovered for contract detection");
+  }
+
+  const merged = mergeContract([
+    ...(modelResult.contract ? [modelResult.contract] : []),
+    ...fileContracts,
+    {
+      expectedVars: [],
+      portRefs: (varsResult.expectedVars ?? [])
+        .filter((v) => isPortLikeVar(v))
+        .map((variable) => ({ variable, source: "variables" as const })),
+      dbNameRefs: (varsResult.expectedVars ?? [])
+        .filter((v) => isDbNameLikeVar(v) && !isPortLikeVar(v))
+        .map((variable) => ({ variable, source: "variables" as const })),
+      projectNameVars: (varsResult.expectedVars ?? []).includes(
+        "COMPOSE_PROJECT_NAME",
+      )
+        ? ["COMPOSE_PROJECT_NAME"]
+        : [],
+      warnings: [],
+    },
+  ]);
+
+  merged.warnings.push(...warnings);
+  return merged;
+}
+
+function parseEnvContent(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const idx = trimmed.indexOf("=");
+    if (idx <= 0) continue;
+    const key = trimmed.slice(0, idx);
+    const value = trimmed.slice(idx + 1);
+    env[key] = value;
+  }
+  return env;
+}
+
+export async function readEnvFile(
+  worktreePath: string,
+): Promise<Record<string, string>> {
+  const envPath = path.join(worktreePath, ".env.worktree");
+  if (!existsSync(envPath)) return {};
+  const raw = await readFile(envPath, "utf-8");
+  return parseEnvContent(raw);
+}
+
+function mapPortVarToCanonical(
+  variable: string,
+): "WEB_PORT" | "API_PORT" | "DB_PORT" {
+  const upper = variable.toUpperCase();
+  if (
+    /(DB|DATABASE|POSTGRES|PG).*PORT|PORT.*(DB|DATABASE|POSTGRES|PG)/.test(
+      upper,
+    )
+  ) {
+    return "DB_PORT";
+  }
+  if (
+    /(API|BACKEND|SERVER|INTERNAL).*PORT|PORT.*(API|BACKEND|SERVER|INTERNAL)/.test(
+      upper,
+    )
+  ) {
+    return "API_PORT";
+  }
+  return "WEB_PORT";
+}
+
+function mapDbVarToCanonical(variable: string): "DB_SCHEMA" {
+  return "DB_SCHEMA";
+}
+
+export function buildAliasMap(
+  contract: ComposeContract,
+  canonicalValues: Record<string, string>,
+): Record<string, string> {
+  const aliases: Record<string, string> = {};
+
+  for (const ref of contract.portRefs) {
+    if (canonicalValues[ref.variable]) continue;
+    const canonical = mapPortVarToCanonical(ref.variable);
+    if (canonicalValues[canonical])
+      aliases[ref.variable] = canonicalValues[canonical];
+  }
+
+  for (const ref of contract.dbNameRefs) {
+    if (canonicalValues[ref.variable]) continue;
+    const canonical = mapDbVarToCanonical(ref.variable);
+    if (canonicalValues[canonical])
+      aliases[ref.variable] = canonicalValues[canonical];
+  }
+
+  for (const variable of contract.projectNameVars) {
+    if (variable === "COMPOSE_PROJECT_NAME" && canonicalValues[variable])
+      continue;
+    if (canonicalValues["COMPOSE_PROJECT_NAME"]) {
+      aliases[variable] = canonicalValues["COMPOSE_PROJECT_NAME"];
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(aliases).sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+export function renderEnvContent(
+  canonicalValues: Record<string, string>,
+  aliasValues: Record<string, string>,
+): string {
+  const canonicalOrder = [
+    "COMPOSE_PROJECT_NAME",
+    "WEB_PORT",
+    "API_PORT",
+    "DB_PORT",
+    "DB_SCHEMA",
+    "SHARED_PROJECT_NAME",
+  ];
+
+  const lines: string[] = [];
+
+  for (const key of canonicalOrder) {
+    if (canonicalValues[key] !== undefined)
+      lines.push(`${key}=${canonicalValues[key]}`);
+  }
+
+  for (const key of Object.keys(canonicalValues).sort((a, b) =>
+    a.localeCompare(b),
+  )) {
+    if (canonicalOrder.includes(key)) continue;
+    lines.push(`${key}=${canonicalValues[key]}`);
+  }
+
+  for (const key of Object.keys(aliasValues).sort((a, b) =>
+    a.localeCompare(b),
+  )) {
+    if (canonicalValues[key] !== undefined) continue;
+    lines.push(`${key}=${aliasValues[key]}`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+function extractPublishedPortsFromDockerPs(rawPortsField: string): number[] {
+  const values = new Set<number>();
+  for (const match of rawPortsField.matchAll(PUBLISHED_PORT_RE)) {
+    const port = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(port)) values.add(port);
+  }
+  return [...values];
+}
+
+async function getRunningDockerPublishedPorts(
+  excludeProject?: string,
+): Promise<Set<number>> {
+  try {
+    const { stdout } = await execa("docker", ["ps", "--format", "json"]);
+    const ports = new Set<number>();
+
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let row: Record<string, unknown>;
+      try {
+        row = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      const labels =
+        typeof row["Labels"] === "string"
+          ? row["Labels"]
+          : typeof row["labels"] === "string"
+            ? row["labels"]
+            : "";
+
+      if (
+        excludeProject &&
+        labels.includes(`com.docker.compose.project=${excludeProject}`)
+      ) {
+        continue;
+      }
+
+      const portsField =
+        typeof row["Ports"] === "string"
+          ? row["Ports"]
+          : typeof row["ports"] === "string"
+            ? row["ports"]
+            : "";
+
+      for (const port of extractPublishedPortsFromDockerPs(portsField)) {
+        ports.add(port);
+      }
+    }
+
+    return ports;
+  } catch {
+    return new Set<number>();
+  }
+}
+
+function toPort(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    return Number.parseInt(value, 10);
+  }
+  return null;
+}
+
+export function analyzeResolvedPorts(
+  resolvedPublishedPorts: Array<{
+    service: string;
+    hostPort: number;
+    targetPort?: number;
+  }>,
+  envVars: Record<string, string>,
+  takenPorts: Set<number>,
+): PreflightIssue[] {
+  const issues: PreflightIssue[] = [];
+
+  for (const port of resolvedPublishedPorts) {
+    if (port.hostPort < 1 || port.hostPort > 65535) {
+      issues.push({
+        severity: "error",
+        message: `Invalid published port for service ${port.service}: ${port.hostPort}`,
+      });
+      continue;
+    }
+
+    if (takenPorts.has(port.hostPort)) {
+      issues.push({
+        severity: "error",
+        message: `Published port collision detected: ${port.hostPort}`,
+        details: `Service ${port.service} resolves to host port ${port.hostPort}, already used by another running container.`,
+        suggestion:
+          "Adjust naming.ports or ensure the alias variable used by compose resolves to a unique host port.",
+      });
+    }
+  }
+
+  const defaultPorts = new Set([3000, 5432]);
+  const canonicalPorts = new Set<number>();
+  for (const key of ["WEB_PORT", "API_PORT", "DB_PORT"]) {
+    const parsed = toPort(envVars[key]);
+    if (parsed !== null) canonicalPorts.add(parsed);
+  }
+
+  for (const port of resolvedPublishedPorts) {
+    if (!defaultPorts.has(port.hostPort)) continue;
+    if (canonicalPorts.has(port.hostPort)) continue;
+    issues.push({
+      severity: "error",
+      message: `Service ${port.service} resolved to default-looking host port ${port.hostPort}`,
+      details:
+        "This often means compose interpolated a fallback default instead of Grove-generated vars.",
+      suggestion:
+        "Add alias variable(s) in .env.worktree or map them via .grove/config.json naming.ports.",
+    });
+  }
+
+  return issues;
+}
+
+export async function preflightComposeEnv(
+  worktreePath: string,
+  contract: ComposeContract,
+  envVars: Record<string, string>,
+): Promise<PreflightResult> {
+  const issues: PreflightIssue[] = [];
+  const projectName = envVars["COMPOSE_PROJECT_NAME"];
+
+  const requiredVars = new Set<string>([
+    ...contract.portRefs.map((r) => r.variable),
+    ...contract.dbNameRefs.map((r) => r.variable),
+    ...contract.projectNameVars,
+  ]);
+
+  for (const variable of requiredVars) {
+    if (!envVars[variable]) {
+      issues.push({
+        severity: "error",
+        message: `Missing required compose variable: ${variable}`,
+        suggestion:
+          "Add alias in .env.worktree or update .grove/config.json naming.ports to cover this variable.",
+      });
+    }
+  }
+
+  let model: Record<string, unknown> | null = null;
+  try {
+    const args = [
+      "compose",
+      "--env-file",
+      ".env.worktree",
+      "config",
+      "--format",
+      "json",
+    ];
+    const { stdout } = await execa("docker", args, { cwd: worktreePath });
+    model = JSON.parse(stdout) as Record<string, unknown>;
+  } catch (error) {
+    const message = (error as Error).message;
+    if (/ENOENT|not found|executable file/i.test(message)) {
+      issues.push({
+        severity: "warning",
+        message: "Compose preflight skipped because Docker CLI is unavailable",
+        details: message,
+      });
+      return { ok: true, issues, resolvedPublishedPorts: [] };
+    }
+
+    issues.push({
+      severity: "error",
+      message: "Compose preflight failed while resolving config",
+      details: message,
+      suggestion:
+        "Run `docker compose --env-file .env.worktree config` to inspect interpolation issues.",
+    });
+    return { ok: false, issues, resolvedPublishedPorts: [] };
+  }
+
+  const services =
+    (model["services"] as Record<string, unknown> | undefined) ?? {};
+  const resolvedPublishedPorts: Array<{
+    service: string;
+    hostPort: number;
+    targetPort?: number;
+  }> = [];
+
+  for (const [serviceName, serviceCfgUnknown] of Object.entries(services)) {
+    const serviceCfg = serviceCfgUnknown as Record<string, unknown>;
+    const ports = serviceCfg["ports"];
+    if (!Array.isArray(ports)) continue;
+
+    for (const entry of ports) {
+      if (typeof entry === "string") {
+        const match = entry.match(
+          /^(?:[^:]+:)?(\d{2,5}):(\d{2,5})(?:\/(?:tcp|udp))?$/,
+        );
+        if (!match) continue;
+        const hostPort = Number.parseInt(match[1], 10);
+        const targetPort = Number.parseInt(match[2], 10);
+        resolvedPublishedPorts.push({
+          service: serviceName,
+          hostPort,
+          targetPort,
+        });
+      } else if (entry && typeof entry === "object") {
+        const published = toPort(
+          (entry as Record<string, unknown>)["published"],
+        );
+        const target = toPort((entry as Record<string, unknown>)["target"]);
+        if (published === null) continue;
+        resolvedPublishedPorts.push({
+          service: serviceName,
+          hostPort: published,
+          targetPort: target ?? undefined,
+        });
+      }
+    }
+  }
+
+  const takenPorts = await getRunningDockerPublishedPorts(projectName);
+  issues.push(
+    ...analyzeResolvedPorts(resolvedPublishedPorts, envVars, takenPorts),
+  );
+
+  return {
+    ok: !issues.some((i) => i.severity === "error"),
+    issues,
+    resolvedPublishedPorts,
+  };
+}
+
+export function formatDoctorEnvReport(
+  contract: ComposeContract,
+  envVars: Record<string, string>,
+  preflight: PreflightResult,
+): string {
+  const missingVars = contract.expectedVars.filter((v) => !envVars[v]);
+
+  const lines: string[] = [];
+  lines.push("Compose expected vars:");
+  lines.push(
+    contract.expectedVars.length > 0
+      ? `  ${contract.expectedVars.join(", ")}`
+      : "  (none discovered)",
+  );
+
+  lines.push("Vars present in .env.worktree:");
+  lines.push(
+    Object.keys(envVars).length > 0
+      ? `  ${Object.keys(envVars)
+          .sort((a, b) => a.localeCompare(b))
+          .join(", ")}`
+      : "  (file missing or empty)",
+  );
+
+  lines.push("Missing vars:");
+  lines.push(
+    missingVars.length > 0 ? `  ${missingVars.join(", ")}` : "  (none)",
+  );
+
+  lines.push("Resolved published host ports:");
+  if (preflight.resolvedPublishedPorts.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const item of preflight.resolvedPublishedPorts) {
+      const target = item.targetPort ? ` -> ${item.targetPort}` : "";
+      lines.push(`  ${item.service}: ${item.hostPort}${target}`);
+    }
+  }
+
+  if (contract.warnings.length > 0) {
+    lines.push("Contract warnings:");
+    for (const warning of contract.warnings) {
+      lines.push(`  - ${warning}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/providers/docker-compose-contract.ts
+++ b/src/providers/docker-compose-contract.ts
@@ -390,7 +390,7 @@ export async function discoverComposeContract(
     ...(modelResult.contract ? [modelResult.contract] : []),
     ...fileContracts,
     {
-      expectedVars: [],
+      expectedVars: varsResult.expectedVars ?? [],
       portRefs: (varsResult.expectedVars ?? [])
         .filter((v) => isPortLikeVar(v))
         .map((variable) => ({ variable, source: "variables" as const })),
@@ -463,18 +463,20 @@ export function buildAliasMap(
   canonicalValues: Record<string, string>,
 ): Record<string, string> {
   const aliases: Record<string, string> = {};
+  const hasCanonical = (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(canonicalValues, key);
 
   for (const ref of contract.portRefs) {
-    if (canonicalValues[ref.variable]) continue;
+    if (hasCanonical(ref.variable)) continue;
     const canonical = mapPortVarToCanonical(ref.variable);
-    if (canonicalValues[canonical])
+    if (hasCanonical(canonical))
       aliases[ref.variable] = canonicalValues[canonical];
   }
 
   for (const ref of contract.dbNameRefs) {
-    if (canonicalValues[ref.variable]) continue;
+    if (hasCanonical(ref.variable)) continue;
     const canonical = mapDbVarToCanonical(ref.variable);
-    if (canonicalValues[canonical])
+    if (hasCanonical(canonical))
       aliases[ref.variable] = canonicalValues[canonical];
   }
 
@@ -655,15 +657,18 @@ export async function preflightComposeEnv(
 ): Promise<PreflightResult> {
   const issues: PreflightIssue[] = [];
   const projectName = envVars["COMPOSE_PROJECT_NAME"];
+  const hasEnvVar = (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(envVars, key);
 
   const requiredVars = new Set<string>([
+    ...contract.expectedVars,
     ...contract.portRefs.map((r) => r.variable),
     ...contract.dbNameRefs.map((r) => r.variable),
     ...contract.projectNameVars,
   ]);
 
   for (const variable of requiredVars) {
-    if (!envVars[variable]) {
+    if (!hasEnvVar(variable)) {
       issues.push({
         severity: "error",
         message: `Missing required compose variable: ${variable}`,
@@ -693,7 +698,11 @@ export async function preflightComposeEnv(
         message: "Compose preflight skipped because Docker CLI is unavailable",
         details: message,
       });
-      return { ok: true, issues, resolvedPublishedPorts: [] };
+      return {
+        ok: !issues.some((i) => i.severity === "error"),
+        issues,
+        resolvedPublishedPorts: [],
+      };
     }
 
     issues.push({
@@ -764,7 +773,9 @@ export function formatDoctorEnvReport(
   envVars: Record<string, string>,
   preflight: PreflightResult,
 ): string {
-  const missingVars = contract.expectedVars.filter((v) => !envVars[v]);
+  const missingVars = contract.expectedVars.filter(
+    (v) => !Object.prototype.hasOwnProperty.call(envVars, v),
+  );
 
   const lines: string[] = [];
   lines.push("Compose expected vars:");

--- a/src/providers/docker-compose-contract.ts
+++ b/src/providers/docker-compose-contract.ts
@@ -2,6 +2,7 @@ import { execa } from "execa";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import path from "path";
+import type { GroveEnvContract } from "../types.js";
 
 const COMPOSE_FILES = [
   "compose.yaml",
@@ -49,6 +50,17 @@ export interface PreflightResult {
     hostPort: number;
     targetPort?: number;
   }>;
+}
+
+export interface EnvResolutionIssue {
+  severity: "error" | "warning";
+  message: string;
+  details?: string;
+}
+
+export interface EnvResolutionResult {
+  values: Record<string, string>;
+  issues: EnvResolutionIssue[];
 }
 
 function uniqSorted(values: Iterable<string>): string[] {
@@ -177,9 +189,6 @@ export function discoverComposeContractFromText(raw: string): ComposeContract {
       }
       if (inPorts || isPortLikeVar(variable)) {
         pushPortRef(portRefs, variable, currentService, "text-scan");
-      }
-      if (inEnvironment && isDbLikeVar(variable)) {
-        pushDbRef(dbNameRefs, variable, currentService, "text-scan");
       }
       if (inEnvironment && isDbNameLikeVar(variable)) {
         pushDbRef(dbNameRefs, variable, currentService, "text-scan");
@@ -433,6 +442,20 @@ export async function readEnvFile(
   return parseEnvContent(raw);
 }
 
+export async function readSourceEnvFiles(
+  worktreePath: string,
+  fileNames: string[] = [".env"],
+): Promise<Record<string, string>> {
+  const merged: Record<string, string> = {};
+  for (const fileName of fileNames) {
+    const filePath = path.join(worktreePath, fileName);
+    if (!existsSync(filePath)) continue;
+    const raw = await readFile(filePath, "utf-8");
+    Object.assign(merged, parseEnvContent(raw));
+  }
+  return merged;
+}
+
 function mapPortVarToCanonical(
   variable: string,
 ): "WEB_PORT" | "API_PORT" | "DB_PORT" {
@@ -454,10 +477,6 @@ function mapPortVarToCanonical(
   return "WEB_PORT";
 }
 
-function mapDbVarToCanonical(variable: string): "DB_SCHEMA" {
-  return "DB_SCHEMA";
-}
-
 export function buildAliasMap(
   contract: ComposeContract,
   canonicalValues: Record<string, string>,
@@ -473,13 +492,6 @@ export function buildAliasMap(
       aliases[ref.variable] = canonicalValues[canonical];
   }
 
-  for (const ref of contract.dbNameRefs) {
-    if (hasCanonical(ref.variable)) continue;
-    const canonical = mapDbVarToCanonical(ref.variable);
-    if (hasCanonical(canonical))
-      aliases[ref.variable] = canonicalValues[canonical];
-  }
-
   for (const variable of contract.projectNameVars) {
     if (variable === "COMPOSE_PROJECT_NAME" && canonicalValues[variable])
       continue;
@@ -491,6 +503,145 @@ export function buildAliasMap(
   return Object.fromEntries(
     Object.entries(aliases).sort(([a], [b]) => a.localeCompare(b)),
   );
+}
+
+function renderTemplate(
+  template: string,
+  context: Record<string, string>,
+): { value?: string; missing: string[] } {
+  const missing: string[] = [];
+  const value = template.replace(/\$\{([A-Z][A-Z0-9_]*)\}/g, (_, key) => {
+    if (Object.prototype.hasOwnProperty.call(context, key)) {
+      return context[key];
+    }
+    missing.push(key);
+    return `\${${key}}`;
+  });
+  return { value: missing.length === 0 ? value : undefined, missing };
+}
+
+export function resolveContractEnvVars(
+  contract: ComposeContract,
+  canonicalValues: Record<string, string>,
+  sourceEnv: Record<string, string>,
+  envContract?: GroveEnvContract,
+): EnvResolutionResult {
+  const strict = Boolean(envContract?.strict);
+  const required = new Set(envContract?.required ?? []);
+  const managed = new Set(envContract?.managed ?? []);
+  const passthrough = new Set(envContract?.passthrough ?? []);
+  const derived = envContract?.derived ?? {};
+  const issues: EnvResolutionIssue[] = [];
+  const values: Record<string, string> = {};
+
+  const hasCanonical = (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(canonicalValues, key);
+  const hasValue = (key: string): boolean =>
+    hasCanonical(key) || Object.prototype.hasOwnProperty.call(values, key);
+  const hasSource = (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(sourceEnv, key);
+  const setValue = (key: string, value: string): void => {
+    if (hasCanonical(key)) return;
+    values[key] = value;
+  };
+
+  const deterministicAliases = buildAliasMap(contract, canonicalValues);
+  for (const [key, value] of Object.entries(deterministicAliases)) {
+    setValue(key, value);
+  }
+
+  for (const variable of managed) {
+    if (hasCanonical(variable)) {
+      setValue(variable, canonicalValues[variable]);
+      continue;
+    }
+    issues.push({
+      severity: required.has(variable) || strict ? "error" : "warning",
+      message: `Managed env var cannot be computed: ${variable}`,
+      details:
+        "Add a deterministic source in Grove config (for example naming.ports or naming templates), or remove it from envContract.managed.",
+    });
+  }
+
+  for (const variable of passthrough) {
+    if (hasValue(variable)) continue;
+    if (hasSource(variable)) {
+      setValue(variable, sourceEnv[variable]);
+      continue;
+    }
+    issues.push({
+      severity: required.has(variable) || strict ? "error" : "warning",
+      message: `Passthrough env var not found in source env: ${variable}`,
+      details:
+        "Ensure the variable exists in .env, .env.worktree, or envContract.sourceEnvFiles.",
+    });
+  }
+
+  for (const [variable, template] of Object.entries(derived)) {
+    if (hasValue(variable)) continue;
+
+    const templateContext: Record<string, string> = {
+      ...sourceEnv,
+      ...canonicalValues,
+      ...values,
+    };
+    const rendered = renderTemplate(template, templateContext);
+    if (rendered.value !== undefined) {
+      setValue(variable, rendered.value);
+      continue;
+    }
+
+    const fallback = hasSource(variable) ? sourceEnv[variable] : undefined;
+    if (fallback !== undefined && !strict && !required.has(variable)) {
+      setValue(variable, fallback);
+      issues.push({
+        severity: "warning",
+        message: `Derived env var ${variable} could not be fully rendered; keeping existing source value`,
+        details: `Missing template vars: ${rendered.missing.join(", ")}`,
+      });
+      continue;
+    }
+
+    issues.push({
+      severity: strict || required.has(variable) ? "error" : "warning",
+      message: `Derived env var ${variable} could not be rendered`,
+      details: `Missing template vars: ${rendered.missing.join(", ")}`,
+    });
+  }
+
+  for (const variable of contract.expectedVars) {
+    if (hasValue(variable)) continue;
+    if (hasSource(variable)) {
+      setValue(variable, sourceEnv[variable]);
+    }
+  }
+
+  for (const variable of required) {
+    if (!hasValue(variable)) {
+      issues.push({
+        severity: "error",
+        message: `Required env var could not be resolved: ${variable}`,
+      });
+    }
+  }
+
+  if (strict) {
+    for (const variable of contract.expectedVars) {
+      if (!hasValue(variable)) {
+        issues.push({
+          severity: "error",
+          message: `Strict env contract: unresolved compose variable ${variable}`,
+        });
+      }
+    }
+  }
+
+  return {
+    values: Object.fromEntries(
+      Object.entries(values).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+    issues,
+  };
 }
 
 export function renderEnvContent(
@@ -654,17 +805,20 @@ export async function preflightComposeEnv(
   worktreePath: string,
   contract: ComposeContract,
   envVars: Record<string, string>,
+  envContract?: GroveEnvContract,
 ): Promise<PreflightResult> {
   const issues: PreflightIssue[] = [];
   const projectName = envVars["COMPOSE_PROJECT_NAME"];
   const hasEnvVar = (key: string): boolean =>
     Object.prototype.hasOwnProperty.call(envVars, key);
+  const strict = Boolean(envContract?.strict);
 
   const requiredVars = new Set<string>([
-    ...contract.expectedVars,
+    ...(strict ? contract.expectedVars : []),
     ...contract.portRefs.map((r) => r.variable),
-    ...contract.dbNameRefs.map((r) => r.variable),
     ...contract.projectNameVars,
+    ...(envContract?.required ?? []),
+    ...Object.keys(envContract?.derived ?? {}),
   ]);
 
   for (const variable of requiredVars) {

--- a/src/providers/docker-compose.ts
+++ b/src/providers/docker-compose.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import path from "path";
 import type { GroveProvider } from "./types.js";
 import type { GroveEnvironment } from "../types.js";
+import { loadGroveConfig } from "../data/groveConfig.js";
 import {
   discoverComposeContract,
   preflightComposeEnv,
@@ -91,6 +92,7 @@ export class DockerComposeProvider implements GroveProvider {
   async start(): Promise<GroveEnvironment> {
     const vars = await parseEnvAgentAsync(this.worktreePath);
     const projectName = vars?.projectName ?? path.basename(this.worktreePath);
+    const config = await loadGroveConfig(this.worktreePath);
 
     const contract = await discoverComposeContract(this.worktreePath);
     const envVars = await readEnvFile(this.worktreePath);
@@ -98,6 +100,7 @@ export class DockerComposeProvider implements GroveProvider {
       this.worktreePath,
       contract,
       envVars,
+      config?.envContract,
     );
     if (!preflight.ok) {
       const lines = ["Compose env preflight failed:"];

--- a/src/providers/docker-compose.ts
+++ b/src/providers/docker-compose.ts
@@ -4,6 +4,11 @@ import { existsSync } from "fs";
 import path from "path";
 import type { GroveProvider } from "./types.js";
 import type { GroveEnvironment } from "../types.js";
+import {
+  discoverComposeContract,
+  preflightComposeEnv,
+  readEnvFile,
+} from "./docker-compose-contract.js";
 
 interface EnvAgentVars {
   projectName: string;
@@ -86,6 +91,30 @@ export class DockerComposeProvider implements GroveProvider {
   async start(): Promise<GroveEnvironment> {
     const vars = await parseEnvAgentAsync(this.worktreePath);
     const projectName = vars?.projectName ?? path.basename(this.worktreePath);
+
+    const contract = await discoverComposeContract(this.worktreePath);
+    const envVars = await readEnvFile(this.worktreePath);
+    const preflight = await preflightComposeEnv(
+      this.worktreePath,
+      contract,
+      envVars,
+    );
+    if (!preflight.ok) {
+      const lines = ["Compose env preflight failed:"];
+      for (const issue of preflight.issues) {
+        lines.push(`- ${issue.message}`);
+        if (issue.details) lines.push(`  ${issue.details}`);
+        if (issue.suggestion) lines.push(`  fix: ${issue.suggestion}`);
+      }
+      throw new Error(lines.join("\n"));
+    }
+
+    for (const issue of preflight.issues.filter(
+      (i) => i.severity === "warning",
+    )) {
+      console.warn(`warning: ${issue.message}`);
+      if (issue.details) console.warn(`  ${issue.details}`);
+    }
 
     await execa(
       "docker",

--- a/src/setup/naming.test.ts
+++ b/src/setup/naming.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from "vitest";
-import { branchSafe, expandNaming, buildEnvAgent } from "./naming.js";
+import {
+  branchSafe,
+  expandNaming,
+  buildEnvAgent,
+  extractPublishedHostPorts,
+} from "./naming.js";
 import type { ExpandedNaming } from "./naming.js";
 import type { GroveConfig } from "../types.js";
 
@@ -91,16 +96,16 @@ describe("expandNaming", () => {
   test("respects explicit port numbers", () => {
     const config: GroveConfig = {
       ...baseConfig,
-      naming: { dbPort: 5544, webPort: 3000, apiPort: 4000 },
+      naming: { dbPort: 62044, webPort: 62000, apiPort: 62001 },
     };
     const result = expandNaming(config, "main");
-    expect(result.dbPort).toBe(5544);
-    expect(result.webPort).toBe(3000);
-    expect(result.apiPort).toBe(4000);
+    expect(result.dbPort).toBe(62044);
+    expect(result.webPort).toBe(62000);
+    expect(result.apiPort).toBe(62001);
     expect(result.ports).toMatchObject({
-      DB_PORT: 5544,
-      WEB_PORT: 3000,
-      API_PORT: 4000,
+      DB_PORT: 62044,
+      WEB_PORT: 62000,
+      API_PORT: 62001,
     });
   });
 
@@ -140,13 +145,13 @@ describe("buildEnvAgent", () => {
     composeProject: "grove-main",
     sharedProject: null,
     dbSchema: "myapp_main",
-    dbPort: 5544,
-    webPort: 3000,
-    apiPort: 4000,
+    dbPort: 62044,
+    webPort: 62000,
+    apiPort: 62001,
     ports: {
-      WEB_PORT: 3000,
-      API_PORT: 4000,
-      DB_PORT: 5544,
+      WEB_PORT: 62000,
+      API_PORT: 62001,
+      DB_PORT: 62044,
     },
   };
 
@@ -157,12 +162,12 @@ describe("buildEnvAgent", () => {
 
   test("includes WEB_PORT", async () => {
     const result = await buildEnvAgent(explicitExpanded);
-    expect(result).toContain("WEB_PORT=3000");
+    expect(result).toContain("WEB_PORT=62000");
   });
 
   test("includes API_PORT", async () => {
     const result = await buildEnvAgent(explicitExpanded);
-    expect(result).toContain("API_PORT=4000");
+    expect(result).toContain("API_PORT=62001");
   });
 
   test("includes DB_SCHEMA", async () => {
@@ -172,7 +177,7 @@ describe("buildEnvAgent", () => {
 
   test("includes DB_PORT", async () => {
     const result = await buildEnvAgent(explicitExpanded);
-    expect(result).toContain("DB_PORT=5544");
+    expect(result).toContain("DB_PORT=62044");
   });
 
   test("does not include SHARED_PROJECT_NAME when sharedProject is null", async () => {
@@ -210,16 +215,37 @@ describe("buildEnvAgent", () => {
     // Keep WEB/API static in this test so we avoid relying on open-port state.
     const expanded: ExpandedNaming = {
       ...explicitExpanded,
-      webPort: 3001,
-      apiPort: 3002,
+      webPort: 62010,
+      apiPort: 62011,
       ports: {
         ...explicitExpanded.ports,
-        WEB_PORT: 3001,
-        API_PORT: 3002,
+        WEB_PORT: 62010,
+        API_PORT: 62011,
       },
     };
     const result = await buildEnvAgent(expanded);
-    expect(result).toContain("WEB_PORT=3001");
-    expect(result).toContain("API_PORT=3002");
+    expect(result).toContain("WEB_PORT=62010");
+    expect(result).toContain("API_PORT=62011");
+  });
+});
+
+describe("extractPublishedHostPorts", () => {
+  test("extracts ports from docker short syntax output", () => {
+    const result = extractPublishedHostPorts(
+      "0.0.0.0:5432->5432/tcp, :::5432->5432/tcp",
+    );
+    expect(result).toContain(5432);
+  });
+
+  test("extracts multiple published host ports", () => {
+    const result = extractPublishedHostPorts(
+      "0.0.0.0:4566->4566/tcp, 0.0.0.0:6379->6379/tcp",
+    );
+    expect(result).toEqual(expect.arrayContaining([4566, 6379]));
+  });
+
+  test("returns empty array when there are no published mappings", () => {
+    const result = extractPublishedHostPorts("443/tcp, 8080/tcp");
+    expect(result).toEqual([]);
   });
 });

--- a/src/setup/naming.test.ts
+++ b/src/setup/naming.test.ts
@@ -3,6 +3,7 @@ import {
   branchSafe,
   expandNaming,
   buildEnvAgent,
+  buildCanonicalEnvVars,
   extractPublishedHostPorts,
 } from "./naming.js";
 import type { ExpandedNaming } from "./naming.js";
@@ -129,6 +130,31 @@ describe("expandNaming", () => {
     });
   });
 
+  test("normalizes scalar canonical ports from naming.ports overrides", () => {
+    const config: GroveConfig = {
+      ...baseConfig,
+      naming: {
+        webPort: 62000,
+        apiPort: 62001,
+        dbPort: 62002,
+        ports: {
+          WEB_PORT: 63000,
+          API_PORT: 63001,
+          DB_PORT: 63002,
+        },
+      },
+    };
+    const result = expandNaming(config, "main");
+    expect(result.webPort).toBe(63000);
+    expect(result.apiPort).toBe(63001);
+    expect(result.dbPort).toBe(63002);
+    expect(result.ports).toMatchObject({
+      WEB_PORT: 63000,
+      API_PORT: 63001,
+      DB_PORT: 63002,
+    });
+  });
+
   test('falls back to "grove" project name when project is missing from config', () => {
     // GroveConfig requires project, but expandNaming reads it with ?? 'grove'
     const config = {
@@ -226,6 +252,24 @@ describe("buildEnvAgent", () => {
     const result = await buildEnvAgent(expanded);
     expect(result).toContain("WEB_PORT=62010");
     expect(result).toContain("API_PORT=62011");
+  });
+
+  test("throws a clear error when two env keys configure the same port", async () => {
+    const expanded: ExpandedNaming = {
+      ...explicitExpanded,
+      dbPort: 64001,
+      webPort: 64001,
+      apiPort: 64002,
+      ports: {
+        WEB_PORT: 64001,
+        API_PORT: 64002,
+        DB_PORT: 64001,
+      },
+    };
+
+    await expect(buildCanonicalEnvVars(expanded)).rejects.toThrow(
+      "WEB_PORT and DB_PORT",
+    );
   });
 });
 

--- a/src/setup/naming.test.ts
+++ b/src/setup/naming.test.ts
@@ -54,8 +54,14 @@ describe("expandNaming", () => {
 
   test("defaults ports to auto", () => {
     const result = expandNaming(baseConfig, "main");
+    expect(result.dbPort).toBe("auto");
     expect(result.webPort).toBe("auto");
     expect(result.apiPort).toBe("auto");
+    expect(result.ports).toMatchObject({
+      WEB_PORT: "auto",
+      API_PORT: "auto",
+      DB_PORT: "auto",
+    });
   });
 
   test("expands branch_safe for slash-containing branch", () => {
@@ -85,11 +91,37 @@ describe("expandNaming", () => {
   test("respects explicit port numbers", () => {
     const config: GroveConfig = {
       ...baseConfig,
-      naming: { webPort: 3000, apiPort: 4000 },
+      naming: { dbPort: 5544, webPort: 3000, apiPort: 4000 },
     };
     const result = expandNaming(config, "main");
+    expect(result.dbPort).toBe(5544);
     expect(result.webPort).toBe(3000);
     expect(result.apiPort).toBe(4000);
+    expect(result.ports).toMatchObject({
+      DB_PORT: 5544,
+      WEB_PORT: 3000,
+      API_PORT: 4000,
+    });
+  });
+
+  test("supports arbitrary service ports via naming.ports", () => {
+    const config: GroveConfig = {
+      ...baseConfig,
+      naming: {
+        ports: {
+          REDIS_PORT: "auto",
+          LOCALSTACK_PORT: 4567,
+        },
+      },
+    };
+    const result = expandNaming(config, "main");
+    expect(result.ports).toMatchObject({
+      REDIS_PORT: "auto",
+      LOCALSTACK_PORT: 4567,
+      WEB_PORT: "auto",
+      API_PORT: "auto",
+      DB_PORT: "auto",
+    });
   });
 
   test('falls back to "grove" project name when project is missing from config', () => {
@@ -108,8 +140,14 @@ describe("buildEnvAgent", () => {
     composeProject: "grove-main",
     sharedProject: null,
     dbSchema: "myapp_main",
+    dbPort: 5544,
     webPort: 3000,
     apiPort: 4000,
+    ports: {
+      WEB_PORT: 3000,
+      API_PORT: 4000,
+      DB_PORT: 5544,
+    },
   };
 
   test("includes COMPOSE_PROJECT_NAME", async () => {
@@ -132,6 +170,11 @@ describe("buildEnvAgent", () => {
     expect(result).toContain("DB_SCHEMA=myapp_main");
   });
 
+  test("includes DB_PORT", async () => {
+    const result = await buildEnvAgent(explicitExpanded);
+    expect(result).toContain("DB_PORT=5544");
+  });
+
   test("does not include SHARED_PROJECT_NAME when sharedProject is null", async () => {
     const result = await buildEnvAgent(explicitExpanded);
     expect(result).not.toContain("SHARED_PROJECT_NAME");
@@ -151,16 +194,32 @@ describe("buildEnvAgent", () => {
     expect(result.endsWith("\n")).toBe(true);
   });
 
-  test("uses existingWebPort as starting point when webPort is auto", async () => {
-    // When webPort is 'auto', it calls findFreePort. We test with an explicit port to avoid
-    // network side effects, but verify the logic by using a fixed port.
+  test("includes arbitrary port env keys", async () => {
     const expanded: ExpandedNaming = {
       ...explicitExpanded,
-      webPort: 8080,
-      apiPort: 8081,
+      ports: {
+        ...explicitExpanded.ports,
+        REDIS_PORT: 6381,
+      },
     };
     const result = await buildEnvAgent(expanded);
-    expect(result).toContain("WEB_PORT=8080");
-    expect(result).toContain("API_PORT=8081");
+    expect(result).toContain("REDIS_PORT=6381");
+  });
+
+  test("uses existingWebPort as starting point when webPort is auto", async () => {
+    // Keep WEB/API static in this test so we avoid relying on open-port state.
+    const expanded: ExpandedNaming = {
+      ...explicitExpanded,
+      webPort: 3001,
+      apiPort: 3002,
+      ports: {
+        ...explicitExpanded.ports,
+        WEB_PORT: 3001,
+        API_PORT: 3002,
+      },
+    };
+    const result = await buildEnvAgent(expanded);
+    expect(result).toContain("WEB_PORT=3001");
+    expect(result).toContain("API_PORT=3002");
   });
 });

--- a/src/setup/naming.test.ts
+++ b/src/setup/naming.test.ts
@@ -44,7 +44,7 @@ describe("branchSafe", () => {
 describe("expandNaming", () => {
   test("uses default composeProject template", () => {
     const result = expandNaming(baseConfig, "main");
-    expect(result.composeProject).toBe("grove-main");
+    expect(result.composeProject).toBe("myapp-main");
   });
 
   test("uses default dbSchema template with project name", () => {
@@ -71,7 +71,7 @@ describe("expandNaming", () => {
 
   test("expands branch_safe for slash-containing branch", () => {
     const result = expandNaming(baseConfig, "feature/my-feature");
-    expect(result.composeProject).toBe("grove-feature-my-feature");
+    expect(result.composeProject).toBe("myapp-feature-my-feature");
     expect(result.dbSchema).toBe("myapp_feature-my-feature");
   });
 

--- a/src/setup/naming.ts
+++ b/src/setup/naming.ts
@@ -28,9 +28,19 @@ export interface ExpandedNaming {
   composeProject: string;
   sharedProject: string | null;
   dbSchema: string;
+  dbPort: number | "auto";
   webPort: number | "auto";
   apiPort: number | "auto";
+  ports: Record<string, number | "auto">;
 }
+
+const DEFAULT_PORT_STARTS: Record<string, number> = {
+  WEB_PORT: 8080,
+  API_PORT: 8081,
+  DB_PORT: 5432,
+  REDIS_PORT: 6379,
+  LOCALSTACK_PORT: 4566,
+};
 
 /**
  * Expand naming templates from .grove/config.json for a specific branch.
@@ -48,6 +58,10 @@ export function expandNaming(
 
   const naming = config.naming ?? {};
 
+  const dbPort = naming.dbPort ?? "auto";
+  const webPort = naming.webPort ?? "auto";
+  const apiPort = naming.apiPort ?? "auto";
+
   return {
     composeProject: expandTemplate(
       naming.composeProject ?? "grove-${branch_safe}",
@@ -60,8 +74,15 @@ export function expandNaming(
       naming.dbSchema ?? "${project}_${branch_safe}",
       vars,
     ),
-    webPort: naming.webPort ?? "auto",
-    apiPort: naming.apiPort ?? "auto",
+    dbPort,
+    webPort,
+    apiPort,
+    ports: {
+      WEB_PORT: webPort,
+      API_PORT: apiPort,
+      DB_PORT: dbPort,
+      ...(naming.ports ?? {}),
+    },
   };
 }
 
@@ -88,6 +109,26 @@ export async function findFreePort(start: number): Promise<number> {
   throw new Error(`Could not find a free port starting from ${start}`);
 }
 
+async function findFreePortWithReserved(
+  start: number,
+  reserved: Set<number>,
+): Promise<number> {
+  for (let p = start; p < start + 200; p++) {
+    if (!reserved.has(p) && (await isPortFree(p))) return p;
+  }
+  throw new Error(`Could not find a free port starting from ${start}`);
+}
+
+function inferStartPort(
+  key: string,
+  resolvedPorts: Record<string, number>,
+): number {
+  if (key === "API_PORT" && resolvedPorts["WEB_PORT"]) {
+    return resolvedPorts["WEB_PORT"] + 1;
+  }
+  return DEFAULT_PORT_STARTS[key] ?? 10000;
+}
+
 /**
  * Build a .env.worktree file body from expanded naming values.
  * The caller is responsible for writing it to disk.
@@ -96,20 +137,42 @@ export async function buildEnvAgent(
   expanded: ExpandedNaming,
   existingWebPort?: number,
 ): Promise<string> {
-  const webPort =
-    expanded.webPort === "auto"
-      ? await findFreePort(existingWebPort ?? 8080)
-      : expanded.webPort;
+  const portSpecs: Record<string, number | "auto"> = {
+    WEB_PORT: expanded.webPort,
+    API_PORT: expanded.apiPort,
+    DB_PORT: expanded.dbPort,
+    ...expanded.ports,
+  };
 
-  const apiPort =
-    expanded.apiPort === "auto"
-      ? await findFreePort(webPort + 1)
-      : expanded.apiPort;
+  const reserved = new Set<number>();
+  const resolvedPorts: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(portSpecs)) {
+    if (typeof value === "number") {
+      if (reserved.has(value)) {
+        throw new Error(`Duplicate port configured: ${value}`);
+      }
+      reserved.add(value);
+      resolvedPorts[key] = value;
+      continue;
+    }
+
+    const start =
+      key === "WEB_PORT"
+        ? (existingWebPort ?? DEFAULT_PORT_STARTS.WEB_PORT)
+        : inferStartPort(key, resolvedPorts);
+    const resolved = await findFreePortWithReserved(start, reserved);
+    reserved.add(resolved);
+    resolvedPorts[key] = resolved;
+  }
+
+  const portLines = Object.entries(resolvedPorts).map(
+    ([key, value]) => `${key}=${value}`,
+  );
 
   const lines = [
     `COMPOSE_PROJECT_NAME=${expanded.composeProject}`,
-    `WEB_PORT=${webPort}`,
-    `API_PORT=${apiPort}`,
+    ...portLines,
     `DB_SCHEMA=${expanded.dbSchema}`,
     ...(expanded.sharedProject
       ? [`SHARED_PROJECT_NAME=${expanded.sharedProject}`]

--- a/src/setup/naming.ts
+++ b/src/setup/naming.ts
@@ -68,7 +68,7 @@ export function expandNaming(
 
   return {
     composeProject: expandTemplate(
-      naming.composeProject ?? "grove-${branch_safe}",
+      naming.composeProject ?? "${project}-${branch_safe}",
       vars,
     ),
     sharedProject: naming.sharedProject
@@ -187,6 +187,18 @@ export async function buildEnvAgent(
   expanded: ExpandedNaming,
   existingWebPort?: number,
 ): Promise<string> {
+  const envVars = await buildCanonicalEnvVars(expanded, existingWebPort);
+  const lines = Object.entries(envVars)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`);
+
+  return lines.join("\n") + "\n";
+}
+
+export async function buildCanonicalEnvVars(
+  expanded: ExpandedNaming,
+  existingWebPort?: number,
+): Promise<Record<string, string>> {
   const portSpecs: Record<string, number | "auto"> = {
     WEB_PORT: expanded.webPort,
     API_PORT: expanded.apiPort,
@@ -216,18 +228,14 @@ export async function buildEnvAgent(
     resolvedPorts[key] = resolved;
   }
 
-  const portLines = Object.entries(resolvedPorts).map(
-    ([key, value]) => `${key}=${value}`,
-  );
-
-  const lines = [
-    `COMPOSE_PROJECT_NAME=${expanded.composeProject}`,
-    ...portLines,
-    `DB_SCHEMA=${expanded.dbSchema}`,
+  return {
+    COMPOSE_PROJECT_NAME: expanded.composeProject,
+    ...Object.fromEntries(
+      Object.entries(resolvedPorts).map(([key, value]) => [key, String(value)]),
+    ),
+    DB_SCHEMA: expanded.dbSchema,
     ...(expanded.sharedProject
-      ? [`SHARED_PROJECT_NAME=${expanded.sharedProject}`]
-      : []),
-  ];
-
-  return lines.join("\n") + "\n";
+      ? { SHARED_PROJECT_NAME: expanded.sharedProject }
+      : {}),
+  };
 }

--- a/src/setup/naming.ts
+++ b/src/setup/naming.ts
@@ -218,7 +218,7 @@ export async function buildCanonicalEnvVars(
       const duplicateKey = configuredByPort.get(value);
       if (duplicateKey) {
         throw new Error(
-          `Port ${value} is configured for both ${duplicateKey} and ${key}.`,
+          `Port ${value} is configured for both ${duplicateKey} and ${key}. Update .grove/config.json naming.ports or naming.webPort/naming.apiPort/naming.dbPort.`,
         );
       }
       if (dockerReserved.has(value)) {

--- a/src/setup/naming.ts
+++ b/src/setup/naming.ts
@@ -65,6 +65,12 @@ export function expandNaming(
   const dbPort = naming.dbPort ?? "auto";
   const webPort = naming.webPort ?? "auto";
   const apiPort = naming.apiPort ?? "auto";
+  const effectivePorts: Record<string, number | "auto"> = {
+    WEB_PORT: webPort,
+    API_PORT: apiPort,
+    DB_PORT: dbPort,
+    ...(naming.ports ?? {}),
+  };
 
   return {
     composeProject: expandTemplate(
@@ -78,15 +84,11 @@ export function expandNaming(
       naming.dbSchema ?? "${project}_${branch_safe}",
       vars,
     ),
-    dbPort,
-    webPort,
-    apiPort,
-    ports: {
-      WEB_PORT: webPort,
-      API_PORT: apiPort,
-      DB_PORT: dbPort,
-      ...(naming.ports ?? {}),
-    },
+    // Keep scalar fields aligned with the effective canonical map.
+    dbPort: effectivePorts.DB_PORT,
+    webPort: effectivePorts.WEB_PORT,
+    apiPort: effectivePorts.API_PORT,
+    ports: effectivePorts,
   };
 }
 
@@ -206,15 +208,26 @@ export async function buildCanonicalEnvVars(
     ...expanded.ports,
   };
 
-  const reserved = new Set<number>(await getDockerPublishedHostPorts());
+  const dockerReserved = new Set<number>(await getDockerPublishedHostPorts());
+  const reserved = new Set<number>(dockerReserved);
+  const configuredByPort = new Map<number, string>();
   const resolvedPorts: Record<string, number> = {};
 
   for (const [key, value] of Object.entries(portSpecs)) {
     if (typeof value === "number") {
-      if (reserved.has(value)) {
-        throw new Error(`Duplicate port configured: ${value}`);
+      const duplicateKey = configuredByPort.get(value);
+      if (duplicateKey) {
+        throw new Error(
+          `Port ${value} is configured for both ${duplicateKey} and ${key}.`,
+        );
+      }
+      if (dockerReserved.has(value)) {
+        throw new Error(
+          `Port ${value} configured for ${key} is already published by a running container.`,
+        );
       }
       reserved.add(value);
+      configuredByPort.set(value, key);
       resolvedPorts[key] = value;
       continue;
     }

--- a/src/setup/naming.ts
+++ b/src/setup/naming.ts
@@ -1,4 +1,5 @@
 import net from "net";
+import { execa } from "execa";
 import type { GroveConfig } from "../types.js";
 
 /**
@@ -41,6 +42,9 @@ const DEFAULT_PORT_STARTS: Record<string, number> = {
   REDIS_PORT: 6379,
   LOCALSTACK_PORT: 4566,
 };
+
+const DOCKER_PUBLISHED_PORT_RE =
+  /(?:^|[\s,])(?:[^\s:,]+:)?(\d{2,5})->\d{2,5}\/(?:tcp|udp)/g;
 
 /**
  * Expand naming templates from .grove/config.json for a specific branch.
@@ -109,6 +113,52 @@ export async function findFreePort(start: number): Promise<number> {
   throw new Error(`Could not find a free port starting from ${start}`);
 }
 
+export function extractPublishedHostPorts(portsField: string): number[] {
+  const discovered = new Set<number>();
+
+  for (const match of portsField.matchAll(DOCKER_PUBLISHED_PORT_RE)) {
+    const value = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(value)) discovered.add(value);
+  }
+
+  return [...discovered];
+}
+
+async function getDockerPublishedHostPorts(): Promise<number[]> {
+  try {
+    const { stdout } = await execa("docker", ["ps", "--format", "json"]);
+    const ports = new Set<number>();
+
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      const field =
+        typeof parsed["Ports"] === "string"
+          ? parsed["Ports"]
+          : typeof parsed["ports"] === "string"
+            ? parsed["ports"]
+            : "";
+
+      for (const port of extractPublishedHostPorts(field)) {
+        ports.add(port);
+      }
+    }
+
+    return [...ports];
+  } catch {
+    // Docker may be unavailable or not running; fall back to socket checks only.
+    return [];
+  }
+}
+
 async function findFreePortWithReserved(
   start: number,
   reserved: Set<number>,
@@ -144,7 +194,7 @@ export async function buildEnvAgent(
     ...expanded.ports,
   };
 
-  const reserved = new Set<number>();
+  const reserved = new Set<number>(await getDockerPublishedHostPorts());
   const resolvedPorts: Record<string, number> = {};
 
   for (const [key, value] of Object.entries(portSpecs)) {

--- a/src/setup/presets.test.ts
+++ b/src/setup/presets.test.ts
@@ -109,7 +109,7 @@ describe("presets.docker.generate", () => {
 
   test("includes naming templates", () => {
     const { naming } = presets.docker.generate(makeDetection());
-    expect(naming?.composeProject).toBe("grove-${branch_safe}");
+    expect(naming?.composeProject).toBe("${project}-${branch_safe}");
     expect(naming?.dbSchema).toBe("${project}_${branch_safe}");
     expect(naming?.ports).toMatchObject({
       WEB_PORT: "auto",
@@ -125,6 +125,12 @@ describe("presets.docker.generate", () => {
     expect(presets.docker.generate(makeDetection()).worktrees?.prefix).toBe(
       "grove",
     );
+  });
+
+  test("sets default base branch", () => {
+    expect(
+      presets.docker.generate(makeDetection()).worktrees?.defaultBaseBranch,
+    ).toBe("main");
   });
 });
 
@@ -162,6 +168,12 @@ describe("presets.vite.generate", () => {
       "grove",
     );
   });
+
+  test("sets default base branch", () => {
+    expect(
+      presets.vite.generate(makeDetection()).worktrees?.defaultBaseBranch,
+    ).toBe("main");
+  });
 });
 
 describe("presets.node.generate", () => {
@@ -197,6 +209,12 @@ describe("presets.node.generate", () => {
     expect(presets.node.generate(makeDetection()).worktrees?.prefix).toBe(
       "grove",
     );
+  });
+
+  test("sets default base branch", () => {
+    expect(
+      presets.node.generate(makeDetection()).worktrees?.defaultBaseBranch,
+    ).toBe("main");
   });
 });
 

--- a/src/setup/presets.test.ts
+++ b/src/setup/presets.test.ts
@@ -111,6 +111,12 @@ describe("presets.docker.generate", () => {
     const { naming } = presets.docker.generate(makeDetection());
     expect(naming?.composeProject).toBe("grove-${branch_safe}");
     expect(naming?.dbSchema).toBe("${project}_${branch_safe}");
+    expect(naming?.ports).toMatchObject({
+      WEB_PORT: "auto",
+      API_PORT: "auto",
+      DB_PORT: "auto",
+    });
+    expect(naming?.dbPort).toBe("auto");
     expect(naming?.webPort).toBe("auto");
     expect(naming?.apiPort).toBe("auto");
   });

--- a/src/setup/presets.ts
+++ b/src/setup/presets.ts
@@ -41,7 +41,7 @@ export const presets: Record<PresetName, Preset> = {
         providers,
         ...(Object.keys(shared).length > 0 ? { shared } : {}),
         naming: {
-          composeProject: "grove-${branch_safe}",
+          composeProject: "${project}-${branch_safe}",
           dbSchema: "${project}_${branch_safe}",
           ports: {
             WEB_PORT: "auto",
@@ -52,7 +52,7 @@ export const presets: Record<PresetName, Preset> = {
           webPort: "auto",
           apiPort: "auto",
         },
-        worktrees: { prefix: "grove" },
+        worktrees: { prefix: "grove", defaultBaseBranch: "main" },
       };
     },
   },
@@ -71,7 +71,7 @@ export const presets: Record<PresetName, Preset> = {
         naming: {
           webPort: "auto",
         },
-        worktrees: { prefix: "grove" },
+        worktrees: { prefix: "grove", defaultBaseBranch: "main" },
       };
     },
   },
@@ -89,7 +89,7 @@ export const presets: Record<PresetName, Preset> = {
         naming: {
           webPort: "auto",
         },
-        worktrees: { prefix: "grove" },
+        worktrees: { prefix: "grove", defaultBaseBranch: "main" },
       };
     },
   },

--- a/src/setup/presets.ts
+++ b/src/setup/presets.ts
@@ -43,6 +43,12 @@ export const presets: Record<PresetName, Preset> = {
         naming: {
           composeProject: "grove-${branch_safe}",
           dbSchema: "${project}_${branch_safe}",
+          ports: {
+            WEB_PORT: "auto",
+            API_PORT: "auto",
+            DB_PORT: "auto",
+          },
+          dbPort: "auto",
           webPort: "auto",
           apiPort: "auto",
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export interface GroveConfigProvider {
  *   ${project}      — project name from this config
  */
 export interface GroveConfigNaming {
-  /** docker compose -p value. Default: "grove-${branch_safe}" */
+  /** docker compose -p value. Default: "${project}-${branch_safe}" */
   composeProject?: string;
   /** docker compose -p value for the shared infrastructure stack. Required to use shared stack features. */
   sharedProject?: string;
@@ -111,6 +111,8 @@ export interface GroveConfig {
   naming?: GroveConfigNaming;
   worktrees?: {
     prefix?: string;
+    /** Default base branch used by `grove start --new` when --base is not provided. Default: "main" */
+    defaultBaseBranch?: string;
     /** Absolute path to place new worktrees. Overrides the default <repo-parent>/<repo-name>-worktrees. */
     root?: string;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,36 @@ export interface GroveConfigNaming {
   apiPort?: number | "auto";
 }
 
+/**
+ * Contract for how Grove should populate non-canonical compose variables.
+ */
+export interface GroveEnvContract {
+  /**
+   * Fail when required or strict-checked variables cannot be resolved.
+   */
+  strict?: boolean;
+  /**
+   * Explicitly managed vars. Grove only sets these when it can deterministically compute a value.
+   */
+  managed?: string[];
+  /**
+   * Copy these vars from source env files (.env by default) or existing .env.worktree.
+   */
+  passthrough?: string[];
+  /**
+   * Template-derived vars, e.g. DATABASE_URL from other vars.
+   */
+  derived?: Record<string, string>;
+  /**
+   * Vars that must be present after rendering.
+   */
+  required?: string[];
+  /**
+   * Source env files for passthrough lookups. Defaults to [".env"].
+   */
+  sourceEnvFiles?: string[];
+}
+
 export interface GroveConfig {
   enabled: boolean;
   project: string;
@@ -109,6 +139,7 @@ export interface GroveConfig {
   providers: Record<string, GroveConfigProvider>;
   shared?: Record<string, boolean>;
   naming?: GroveConfigNaming;
+  envContract?: GroveEnvContract;
   worktrees?: {
     prefix?: string;
     /** Default base branch used by `grove start --new` when --base is not provided. Default: "main" */

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,13 @@ export interface GroveConfigNaming {
   sharedProject?: string;
   /** DB schema name. Default: "${project}_${branch_safe}" */
   dbSchema?: string;
+  /**
+   * Generic host-port mapping to emit into .env.worktree (e.g. WEB_PORT, DB_PORT, REDIS_PORT).
+   * Use "auto" to find a free host port at spin time.
+   */
+  ports?: Record<string, number | "auto">;
+  /** DB host port. "auto" finds a free port at spin time. Default: "auto" */
+  dbPort?: number | "auto";
   /** Web port. "auto" finds a free port at spin time. Default: "auto" */
   webPort?: number | "auto";
   /** API / secondary service port. Default: "auto" */

--- a/src/utils/hardcodedPortsCheck.test.ts
+++ b/src/utils/hardcodedPortsCheck.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import os from "os";
+import { findHardcodedComposePortFindings } from "./hardcodedPortsCheck.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(os.tmpdir(), "grove-hardcoded-ports-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("findHardcodedComposePortFindings", () => {
+  test("detects short syntax hardcoded host:container ports", async () => {
+    await writeFile(
+      join(tmpDir, "compose.yaml"),
+      [
+        "services:",
+        "  db:",
+        "    image: postgres:16",
+        "    ports:",
+        '      - "5432:5432"',
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const findings = await findHardcodedComposePortFindings(tmpDir);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      file: "compose.yaml",
+      line: 5,
+    });
+  });
+
+  test("does not flag env-based port mappings", async () => {
+    await writeFile(
+      join(tmpDir, "docker-compose.yml"),
+      [
+        "services:",
+        "  db:",
+        "    ports:",
+        '      - "${DB_PORT:-5432}:5432"',
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const findings = await findHardcodedComposePortFindings(tmpDir);
+    expect(findings).toHaveLength(0);
+  });
+
+  test("detects long syntax published host ports", async () => {
+    await writeFile(
+      join(tmpDir, "compose.yml"),
+      [
+        "services:",
+        "  redis:",
+        "    ports:",
+        "      - target: 6379",
+        "        published: 6379",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const findings = await findHardcodedComposePortFindings(tmpDir);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      file: "compose.yml",
+      line: 5,
+    });
+  });
+
+  test("includes configured extra compose files", async () => {
+    await mkdir(join(tmpDir, "docker"), { recursive: true });
+    await writeFile(
+      join(tmpDir, "docker", "compose.shared.yaml"),
+      ["services:", "  localstack:", "    ports:", '      - "4566:4566"'].join(
+        "\n",
+      ),
+      "utf-8",
+    );
+
+    const findings = await findHardcodedComposePortFindings(tmpDir, [
+      "docker/compose.shared.yaml",
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      file: "docker/compose.shared.yaml",
+      line: 4,
+    });
+  });
+});

--- a/src/utils/hardcodedPortsCheck.ts
+++ b/src/utils/hardcodedPortsCheck.ts
@@ -1,0 +1,106 @@
+import chalk from "chalk";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+
+const DEFAULT_COMPOSE_FILES = [
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  "compose.yml",
+  "compose.yaml",
+];
+
+const SHORT_SYNTAX_PORT_RE =
+  /^\s*-\s*["']?(?:(?:\d{1,3}\.){3}\d{1,3}:)?\d{2,5}:\d{2,5}(?:\/(?:tcp|udp))?["']?\s*(?:#.*)?$/;
+const LONG_SYNTAX_PUBLISHED_RE = /^\s*published\s*:\s*\d{2,5}\s*(?:#.*)?$/;
+
+export interface HardcodedPortFinding {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function isHardcodedPortLine(line: string): boolean {
+  if (line.includes("${")) return false;
+  return SHORT_SYNTAX_PORT_RE.test(line) || LONG_SYNTAX_PUBLISHED_RE.test(line);
+}
+
+function buildCandidateFiles(
+  repoPath: string,
+  extraComposeFiles: string[] = [],
+): string[] {
+  const candidates = new Set<string>(
+    DEFAULT_COMPOSE_FILES.map((f) => path.join(repoPath, f)),
+  );
+
+  for (const extraFile of extraComposeFiles) {
+    const abs = path.isAbsolute(extraFile)
+      ? extraFile
+      : path.join(repoPath, extraFile);
+    candidates.add(abs);
+  }
+
+  return [...candidates];
+}
+
+export async function findHardcodedComposePortFindings(
+  repoPath: string,
+  extraComposeFiles: string[] = [],
+): Promise<HardcodedPortFinding[]> {
+  const findings: HardcodedPortFinding[] = [];
+  const candidates = buildCandidateFiles(repoPath, extraComposeFiles);
+
+  for (const file of candidates) {
+    if (!existsSync(file)) continue;
+
+    const raw = await readFile(file, "utf-8");
+    const lines = raw.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!isHardcodedPortLine(line)) continue;
+      findings.push({
+        file: path.relative(repoPath, file),
+        line: i + 1,
+        text: line.trim(),
+      });
+    }
+  }
+
+  return findings;
+}
+
+export async function warnIfHardcodedComposePorts(
+  repoPath: string,
+  extraComposeFiles: string[] = [],
+): Promise<void> {
+  const findings = await findHardcodedComposePortFindings(
+    repoPath,
+    extraComposeFiles,
+  );
+  if (findings.length === 0) return;
+
+  process.stderr.write(
+    chalk.yellow(
+      "\n  ⚠  grove: likely hardcoded host ports found in compose files.\n",
+    ),
+  );
+
+  for (const finding of findings.slice(0, 6)) {
+    process.stderr.write(
+      chalk.gray(`     ${finding.file}:${finding.line}  ${finding.text}\n`),
+    );
+  }
+
+  if (findings.length > 6) {
+    process.stderr.write(
+      chalk.gray(`     ...and ${findings.length - 6} more\n`),
+    );
+  }
+
+  process.stderr.write(
+    chalk.gray(
+      "     Prefer env-based mappings (e.g. ${DB_PORT:-5432}:5432) to avoid branch collisions.\n\n",
+    ),
+  );
+}


### PR DESCRIPTION
This pull request introduces improved support for environment variable generation and Docker Compose contract detection in Grove, along with several documentation and workflow enhancements. The main changes include automatic alias generation for Compose environment variables, new commands and options for regenerating `.env.worktree`, improved preflight checks for Compose contracts, and updates to the configuration schema and documentation to reflect these features.

**Docker Compose environment and contract improvements:**

* Added automatic detection of expected Compose environment variables and generation of aliases in `.env.worktree`, ensuring compatibility with various Compose contracts and reducing manual configuration. [[1]](diffhunk://#diff-052d91a0fc4ece22660fe31c18deb32acbbd41be82b67d759d0600558e838634R135-R201) [[2]](diffhunk://#diff-052d91a0fc4ece22660fe31c18deb32acbbd41be82b67d759d0600558e838634R289-R292) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L228-R304)
* Implemented preflight checks before `docker compose up` to detect missing variables, host-port collisions, and fallback-to-default mismatches, with actionable error messages.

**New commands and options:**

* Introduced the `--refresh-env` option to `grove setup` and `grove start`, allowing users to regenerate `.env.worktree` from the current Grove config, and documented its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R173) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R608-R610) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L157-R195) [[4]](diffhunk://#diff-052d91a0fc4ece22660fe31c18deb32acbbd41be82b67d759d0600558e838634R210) [[5]](diffhunk://#diff-052d91a0fc4ece22660fe31c18deb32acbbd41be82b67d759d0600558e838634R327-R330)
* Added `grove doctor env` for diagnosing environment mismatches between the generated env file and the Compose contract.

**Configuration and schema updates:**

* Updated `.grove/config.json` and documentation to support and describe the new `naming.ports` mapping for arbitrary service ports, and clarified the use of `worktrees.defaultBaseBranch`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R147) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L188-R214) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R285-R292) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L267-R319)

**Documentation improvements:**

* Expanded and clarified documentation throughout `README.md` to cover new features, configuration options, troubleshooting steps, and best practices for Compose integration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L188-R214) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R231-R255) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R641-R669)

**Bug fixes and code quality:**

* Fixed the default Compose project naming template to use `${project}-${branch_safe}` for improved clarity and consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R147) [[2]](diffhunk://#diff-1d27e7e6a4c030056f3c2c67f1317d970512ac51631fec820b37325335422868L59-R59)

These changes make Grove more robust and user-friendly for projects using Docker Compose, reducing manual intervention and improving environment reproducibility.