### PR TITLE
fix: stop implicit compose var passthrough in .env.worktree

### DIFF
--- a/src/providers/docker-compose-contract.test.ts
+++ b/src/providers/docker-compose-contract.test.ts
@@ -170,6 +170,67 @@ services:
     );
     expect(result.values["DATABASE_URL"]).toBeUndefined();
   });
+
+  test("does not implicitly passthrough discovered compose vars", () => {
+    const contract = discoverComposeContractFromText(`
+services:
+  app:
+    environment:
+      NODE_ENV: \${NODE_ENV}
+      POSTGIS_IMAGE: \${POSTGIS_IMAGE}
+`);
+
+    const result = resolveContractEnvVars(
+      contract,
+      {
+        COMPOSE_PROJECT_NAME: "grove-branch",
+        WEB_PORT: "8088",
+        API_PORT: "8089",
+        DB_PORT: "15432",
+        DB_SCHEMA: "myapp_branch",
+      },
+      {
+        NODE_ENV: "development",
+        POSTGIS_IMAGE: "postgis/postgis:17-3.5",
+      },
+    );
+
+    expect(result.values["NODE_ENV"]).toBeUndefined();
+    expect(result.values["POSTGIS_IMAGE"]).toBeUndefined();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  test("copies passthrough vars only when explicitly configured", () => {
+    const contract = discoverComposeContractFromText(`
+services:
+  app:
+    environment:
+      NODE_ENV: \${NODE_ENV}
+      POSTGIS_IMAGE: \${POSTGIS_IMAGE}
+`);
+
+    const result = resolveContractEnvVars(
+      contract,
+      {
+        COMPOSE_PROJECT_NAME: "grove-branch",
+        WEB_PORT: "8088",
+        API_PORT: "8089",
+        DB_PORT: "15432",
+        DB_SCHEMA: "myapp_branch",
+      },
+      {
+        NODE_ENV: "development",
+        POSTGIS_IMAGE: "postgis/postgis:17-3.5",
+      },
+      {
+        passthrough: ["NODE_ENV", "POSTGIS_IMAGE"],
+      },
+    );
+
+    expect(result.values["NODE_ENV"]).toBe("development");
+    expect(result.values["POSTGIS_IMAGE"]).toBe("postgis/postgis:17-3.5");
+    expect(result.issues).toHaveLength(0);
+  });
 });
 
 describe("renderEnvContent", () => {

--- a/src/providers/docker-compose-contract.ts
+++ b/src/providers/docker-compose-contract.ts
@@ -609,13 +609,6 @@ export function resolveContractEnvVars(
     });
   }
 
-  for (const variable of contract.expectedVars) {
-    if (hasValue(variable)) continue;
-    if (hasSource(variable)) {
-      setValue(variable, sourceEnv[variable]);
-    }
-  }
-
   for (const variable of required) {
     if (!hasValue(variable)) {
       issues.push({


### PR DESCRIPTION
This pull request refines how environment variables are handled in Docker Compose contract resolution, ensuring that only explicitly configured passthrough variables are copied from the source environment. It also adds tests to verify this behavior.

**Environment variable passthrough handling:**

* Removed the implicit passthrough of discovered environment variables in `resolveContractEnvVars`, so variables are only passed through when explicitly configured.

**Test coverage improvements:**

* Added tests to `docker-compose-contract.test.ts` to ensure that environment variables are not implicitly passed through and are only copied when explicitly listed in the `passthrough` configuration.