### PR TITLE
fix: another fix for default branch

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -8,6 +8,7 @@ import type { GroveConfig } from "../types.js";
 import { warnIfHardcodedComposePorts } from "../utils/hardcodedPortsCheck.js";
 import { DEFAULT_SHARED_COMPOSE_FILE } from "../providers/shared.js";
 import { expandNaming, buildCanonicalEnvVars } from "../setup/naming.js";
+import { detectDefaultBranch } from "../data/worktrees.js";
 import { execa } from "execa";
 import { loadGroveConfig } from "../data/groveConfig.js";
 import {
@@ -325,6 +326,19 @@ export async function runSetup(
 
   // 3. Generate config
   const config = preset.generate(detection);
+  try {
+    const defaultBaseBranch = await detectDefaultBranch(repoPath);
+    config.worktrees = {
+      ...(config.worktrees ?? {}),
+      defaultBaseBranch,
+    };
+    debugLog(opts.debug, `detected default base branch: ${defaultBaseBranch}`);
+  } catch {
+    debugLog(
+      opts.debug,
+      `default base branch detection failed; using preset default (${config.worktrees?.defaultBaseBranch ?? "main"})`,
+    );
+  }
 
   await warnIfHardcodedComposePorts(repoPath, [
     config.sharedComposeFile ?? DEFAULT_SHARED_COMPOSE_FILE,

--- a/src/data/worktrees.test.ts
+++ b/src/data/worktrees.test.ts
@@ -283,6 +283,16 @@ describe("loadWorktrees", () => {
 });
 
 describe("detectDefaultBranch", () => {
+  test("returns develop when origin/HEAD points at origin/develop", async () => {
+    mockedExeca.mockResolvedValueOnce({
+      stdout: "origin/develop\n",
+    } as ReturnType<typeof execa>); // symbolic-ref succeeds
+    mockedExeca.mockResolvedValueOnce({ stdout: "abc123" } as ReturnType<
+      typeof execa
+    >); // local "develop" exists
+    expect(await detectDefaultBranch("/repo")).toBe("develop");
+  });
+
   test("returns short branch name from origin/HEAD when local branch exists", async () => {
     mockedExeca.mockResolvedValueOnce({
       stdout: "origin/main\n",


### PR DESCRIPTION
This pull request enhances the setup process by automatically detecting the default base branch of a repository and incorporating it into the generated configuration. It also adds tests to ensure this detection works as expected.

**Setup improvements:**

* The `runSetup` function in `src/commands/setup.ts` now attempts to detect the repository's default base branch using the new `detectDefaultBranch` function and sets it in the generated `config.worktrees.defaultBaseBranch`. If detection fails, it falls back to the preset default (usually "main").
* The `detectDefaultBranch` function is imported from `src/data/worktrees.js` to facilitate this detection.

**Testing enhancements:**

* Added a test case in `src/data/worktrees.test.ts` to verify that `detectDefaultBranch` returns "develop" when `origin/HEAD` points at `origin/develop` and the local "develop" branch exists.