### PR TITLE
feat: add examples and e2e like tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Run tests
         run: npm run test:run
+
+      - name: Run example e2e tests
+        run: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check formatting
         run: npx prettier --check .
 
+      - name: Build
+        run: npm run build
+
       - name: Run tests
         run: npm run test:run
 

--- a/examples/docker-basic/expected/grove.config.json
+++ b/examples/docker-basic/expected/grove.config.json
@@ -1,0 +1,26 @@
+{
+  "enabled": true,
+  "project": "docker-basic",
+  "providers": {
+    "web": {
+      "type": "docker-compose",
+      "service": "web"
+    }
+  },
+  "naming": {
+    "composeProject": "${project}-${branch_safe}",
+    "dbSchema": "${project}_${branch_safe}",
+    "ports": {
+      "WEB_PORT": "auto",
+      "API_PORT": "auto",
+      "DB_PORT": "auto"
+    },
+    "dbPort": "auto",
+    "webPort": "auto",
+    "apiPort": "auto"
+  },
+  "worktrees": {
+    "prefix": "grove",
+    "defaultBaseBranch": "main"
+  }
+}

--- a/examples/docker-basic/template/README.md
+++ b/examples/docker-basic/template/README.md
@@ -1,0 +1,10 @@
+# docker-basic
+
+A minimal Docker Compose project used as a GitGrove example and test fixture.
+
+## Usage
+
+```bash
+grove setup
+grove start main
+```

--- a/examples/docker-basic/template/README.md
+++ b/examples/docker-basic/template/README.md
@@ -1,10 +1,10 @@
 # docker-basic
 
-A minimal Docker Compose project used as a GitGrove example and test fixture.
+A minimal Docker Compose project used as a grove example and test fixture.
 
 ## Usage
 
 ```bash
 grove setup
-grove start main
+grove start feature/my-branch
 ```

--- a/examples/docker-basic/template/docker-compose.yml
+++ b/examples/docker-basic/template/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - "${WEB_PORT:-3000}:3000"
     environment:
       - NODE_ENV=development
+    command: >
+      node -e "require('http').createServer((_,r)=>r.end('docker-basic\n')).listen(3000,()=>console.log('listening on 3000'))"

--- a/examples/docker-basic/template/docker-compose.yml
+++ b/examples/docker-basic/template/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  web:
+    image: node:18-alpine
+    working_dir: /app
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    environment:
+      - NODE_ENV=development

--- a/examples/docker-basic/template/package.json
+++ b/examples/docker-basic/template/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "docker-basic",
+  "version": "1.0.0",
+  "description": "A Docker Compose project"
+}

--- a/examples/node-basic/expected/grove.config.json
+++ b/examples/node-basic/expected/grove.config.json
@@ -1,0 +1,17 @@
+{
+  "enabled": true,
+  "project": "node-basic",
+  "providers": {
+    "web": {
+      "type": "node-scripts",
+      "command": "dev"
+    }
+  },
+  "naming": {
+    "webPort": "auto"
+  },
+  "worktrees": {
+    "prefix": "grove",
+    "defaultBaseBranch": "main"
+  }
+}

--- a/examples/node-basic/template/README.md
+++ b/examples/node-basic/template/README.md
@@ -1,0 +1,10 @@
+# node-basic
+
+A minimal Node.js project used as a GitGrove example and test fixture.
+
+## Usage
+
+```bash
+grove setup
+grove start main
+```

--- a/examples/node-basic/template/README.md
+++ b/examples/node-basic/template/README.md
@@ -1,10 +1,10 @@
 # node-basic
 
-A minimal Node.js project used as a GitGrove example and test fixture.
+A minimal Node.js project used as a grove example and test fixture.
 
 ## Usage
 
 ```bash
 grove setup
-grove start main
+grove start feature/my-branch
 ```

--- a/examples/node-basic/template/package.json
+++ b/examples/node-basic/template/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-basic",
+  "version": "1.0.0",
+  "description": "A basic Node.js project",
+  "scripts": {
+    "dev": "node src/index.js",
+    "start": "node src/index.js"
+  }
+}

--- a/examples/node-basic/template/src/index.js
+++ b/examples/node-basic/template/src/index.js
@@ -1,0 +1,5 @@
+const http = require("http");
+const port = process.env.WEB_PORT ?? 3000;
+http
+  .createServer((_, res) => res.end("node-basic running\n"))
+  .listen(port, () => console.log(`listening on ${port}`));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "node dist/index.js",
     "test": "vitest",
     "test:run": "vitest run",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "test:e2e": "tsc && vitest run --config vitest.e2e.config.ts"
   },
   "dependencies": {
     "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "coverage": "vitest run --coverage",
-    "test:e2e": "tsc && vitest run --config vitest.e2e.config.ts"
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
   },
   "dependencies": {
     "chalk": "^5.3.0",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -56,6 +56,9 @@ function checkGroveConfig(repoRoot: string): DoctorCheck {
   };
 }
 
+// .env.worktree lives in the current worktree directory (which may be the repo
+// root when running from the main checkout). It is optional — the check is
+// informational when missing rather than a hard failure.
 function checkEnvWorktree(repoRoot: string): DoctorCheck {
   const ok = existsSync(path.join(repoRoot, ".env.worktree"));
   return {
@@ -68,6 +71,7 @@ function checkEnvWorktree(repoRoot: string): DoctorCheck {
   };
 }
 
+// Only detects catastrophic git failure — not stale/prunable entries.
 async function checkWorktreeState(repoRoot: string): Promise<DoctorCheck> {
   try {
     await execa("git", ["worktree", "list"], { cwd: repoRoot });
@@ -76,7 +80,8 @@ async function checkWorktreeState(repoRoot: string): Promise<DoctorCheck> {
     return {
       name: "Git worktree state is valid",
       ok: false,
-      message: "git worktree list failed — run `git worktree prune` to repair",
+      message:
+        "git worktree list failed — the repository may be in an inconsistent state",
     };
   }
 }
@@ -124,7 +129,7 @@ export function formatDoctorReport(result: DoctorResult): string {
 export async function runDoctor(
   cwd: string,
   opts: { json?: boolean } = {},
-): Promise<void> {
+): Promise<DoctorResult> {
   const result = await runDoctorChecks(cwd);
 
   if (opts.json) {
@@ -132,7 +137,12 @@ export async function runDoctor(
       JSON.stringify(
         {
           ok: result.ok,
-          checks: result.checks.map(({ name, ok }) => ({ name, ok })),
+          checks: result.checks.map(({ name, ok, optional, message }) => ({
+            name,
+            ok,
+            ...(optional !== undefined ? { optional } : {}),
+            ...(message !== undefined ? { message } : {}),
+          })),
         },
         null,
         2,
@@ -142,7 +152,5 @@ export async function runDoctor(
     console.log("\n" + formatDoctorReport(result) + "\n");
   }
 
-  if (!result.ok) {
-    process.exit(1);
-  }
+  return result;
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,148 @@
+import { existsSync } from "fs";
+import path from "path";
+import chalk from "chalk";
+import { execa } from "execa";
+
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  optional?: boolean;
+  message?: string;
+}
+
+export interface DoctorResult {
+  ok: boolean;
+  checks: DoctorCheck[];
+}
+
+async function checkGitRepo(
+  cwd: string,
+): Promise<{ check: DoctorCheck; repoRoot: string | null }> {
+  try {
+    const { stdout } = await execa("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+    });
+    return {
+      check: { name: "Git repository detected", ok: true },
+      repoRoot: stdout.trim(),
+    };
+  } catch {
+    return {
+      check: {
+        name: "Git repository detected",
+        ok: false,
+        message: "Run grove commands from inside a git repository",
+      },
+      repoRoot: null,
+    };
+  }
+}
+
+function checkGroveDir(repoRoot: string): DoctorCheck {
+  const ok = existsSync(path.join(repoRoot, ".grove"));
+  return {
+    name: ".grove directory exists",
+    ok,
+    message: ok ? undefined : "Run `grove setup` to initialize",
+  };
+}
+
+function checkGroveConfig(repoRoot: string): DoctorCheck {
+  const ok = existsSync(path.join(repoRoot, ".grove", "config.json"));
+  return {
+    name: "config.json exists",
+    ok,
+    message: ok ? undefined : "Run `grove setup` to create it",
+  };
+}
+
+function checkEnvWorktree(repoRoot: string): DoctorCheck {
+  const ok = existsSync(path.join(repoRoot, ".env.worktree"));
+  return {
+    name: ".env.worktree exists",
+    ok,
+    optional: true,
+    message: ok
+      ? undefined
+      : "Run `grove start` or `grove setup --refresh-env` to generate it",
+  };
+}
+
+async function checkWorktreeState(repoRoot: string): Promise<DoctorCheck> {
+  try {
+    await execa("git", ["worktree", "list"], { cwd: repoRoot });
+    return { name: "Git worktree state is valid", ok: true };
+  } catch {
+    return {
+      name: "Git worktree state is valid",
+      ok: false,
+      message: "git worktree list failed — run `git worktree prune` to repair",
+    };
+  }
+}
+
+export async function runDoctorChecks(cwd: string): Promise<DoctorResult> {
+  const checks: DoctorCheck[] = [];
+
+  const { check: gitCheck, repoRoot } = await checkGitRepo(cwd);
+  checks.push(gitCheck);
+
+  if (!repoRoot) {
+    return { ok: false, checks };
+  }
+
+  checks.push(checkGroveDir(repoRoot));
+  checks.push(checkGroveConfig(repoRoot));
+  checks.push(checkEnvWorktree(repoRoot));
+
+  const worktreeCheck = await checkWorktreeState(repoRoot);
+  checks.push(worktreeCheck);
+
+  const ok = checks.every((c) => c.ok || c.optional === true);
+  return { ok, checks };
+}
+
+export function formatDoctorReport(result: DoctorResult): string {
+  const lines = result.checks.map((check) => {
+    if (check.ok) {
+      return chalk.green("✔") + " " + check.name;
+    }
+    if (check.optional) {
+      const line = chalk.yellow("–") + " " + chalk.gray(check.name);
+      return check.message
+        ? line + "\n" + chalk.gray(`  → ${check.message}`)
+        : line;
+    }
+    const line = chalk.red("✖") + " " + chalk.bold(check.name);
+    return check.message
+      ? line + "\n" + chalk.gray(`  → ${check.message}`)
+      : line;
+  });
+  return lines.join("\n");
+}
+
+export async function runDoctor(
+  cwd: string,
+  opts: { json?: boolean } = {},
+): Promise<void> {
+  const result = await runDoctorChecks(cwd);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: result.ok,
+          checks: result.checks.map(({ name, ok }) => ({ name, ok })),
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log("\n" + formatDoctorReport(result) + "\n");
+  }
+
+  if (!result.ok) {
+    process.exit(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
 import { loadGroveConfig } from "./data/groveConfig.js";
 import { expandNaming } from "./setup/naming.js";
 import { runSetup } from "./commands/setup.js";
+import { runDoctor } from "./commands/doctor.js";
 import { warnIfNotGitignored } from "./utils/gitignoreCheck.js";
 import { warnIfHardcodedComposePorts } from "./utils/hardcodedPortsCheck.js";
 import {
@@ -918,6 +919,12 @@ program
   );
 
 const doctor = program.command("doctor").description("Run Grove diagnostics");
+
+doctor
+  .option("--json", "Output diagnostics as JSON")
+  .action(async (opts: { json?: boolean }) => {
+    await runDoctor(process.cwd(), { json: opts.json });
+  });
 
 doctor
   .command("env [branch]")

--- a/src/index.ts
+++ b/src/index.ts
@@ -918,12 +918,21 @@ program
     },
   );
 
+// `grove doctor`     — runs health checks (action below)
+// `grove doctor env` — inspects compose env contract (subcommand below)
+// --json is scoped to the parent; it is not visible to `doctor env`.
 const doctor = program.command("doctor").description("Run Grove diagnostics");
 
 doctor
   .option("--json", "Output diagnostics as JSON")
   .action(async (opts: { json?: boolean }) => {
-    await runDoctor(process.cwd(), { json: opts.json });
+    try {
+      const result = await runDoctor(process.cwd(), { json: opts.json });
+      if (!result.ok) process.exit(1);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
   });
 
 doctor

--- a/tests/e2e/examples.spec.ts
+++ b/tests/e2e/examples.spec.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect, afterEach, beforeAll } from "vitest";
+import { existsSync } from "fs";
+import {
+  CLI_BIN,
+  createTempExampleRepo,
+  readExpectedFile,
+  readGeneratedFile,
+  runGroveDoctor,
+  runGroveSetup,
+  type TempRepo,
+} from "./helpers.js";
+
+beforeAll(() => {
+  if (!existsSync(CLI_BIN)) {
+    throw new Error(
+      `CLI binary not found at ${CLI_BIN}.\nRun \`npm run build\` before running e2e tests.`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// node-basic
+// ---------------------------------------------------------------------------
+
+describe("node-basic example", () => {
+  let repo: TempRepo | undefined;
+
+  afterEach(async () => {
+    await repo?.cleanup();
+    repo = undefined;
+  });
+
+  test("grove setup exits 0 and creates .grove/config.json", async () => {
+    repo = await createTempExampleRepo("node-basic");
+
+    const setup = await runGroveSetup(repo.repoPath);
+    expect(setup.exitCode).toBe(0);
+    expect(existsSync(`${repo.repoPath}/.grove/config.json`)).toBe(true);
+  });
+
+  test("generated config has correct project and provider shape", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const raw = await readGeneratedFile(repo.repoPath, ".grove/config.json");
+    const config = JSON.parse(raw);
+
+    expect(config.enabled).toBe(true);
+    expect(config.project).toBe("node-basic");
+    expect(config.providers.web.type).toBe("node-scripts");
+    expect(config.providers.web.command).toBe("dev");
+  });
+
+  test("generated config matches expected snapshot", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const generated = JSON.parse(
+      await readGeneratedFile(repo.repoPath, ".grove/config.json"),
+    );
+    const expected = JSON.parse(
+      await readExpectedFile("node-basic", ".grove/config.json"),
+    );
+
+    expect(generated).toEqual(expected);
+  });
+
+  test("grove doctor passes after setup", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const doctor = await runGroveDoctor(repo.repoPath);
+    expect(doctor.exitCode).toBe(0);
+    expect(doctor.stdout).toContain("Git repository detected");
+    expect(doctor.stdout).toContain(".grove directory exists");
+    expect(doctor.stdout).toContain("config.json exists");
+  });
+
+  test("grove doctor --json returns structured success output", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const doctor = await runGroveDoctor(repo.repoPath, ["--json"]);
+    expect(doctor.exitCode).toBe(0);
+
+    const result = JSON.parse(doctor.stdout) as {
+      ok: boolean;
+      checks: { name: string; ok: boolean }[];
+    };
+
+    expect(result.ok).toBe(true);
+    expect(Array.isArray(result.checks)).toBe(true);
+
+    const byName = Object.fromEntries(result.checks.map((c) => [c.name, c.ok]));
+    expect(byName["Git repository detected"]).toBe(true);
+    expect(byName[".grove directory exists"]).toBe(true);
+    expect(byName["config.json exists"]).toBe(true);
+    expect(byName["Git worktree state is valid"]).toBe(true);
+  });
+
+  test("grove doctor fails when grove is not set up", async () => {
+    repo = await createTempExampleRepo("node-basic");
+
+    // No `grove setup` — doctor should detect missing config
+    const doctor = await runGroveDoctor(repo.repoPath);
+    expect(doctor.exitCode).toBe(1);
+    expect(doctor.stdout).toContain("Git repository detected");
+    expect(doctor.stdout).toContain("config.json exists");
+  });
+
+  test("grove setup --refresh-env generates .env.worktree", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath, ["--refresh-env"]);
+
+    expect(existsSync(`${repo.repoPath}/.env.worktree`)).toBe(true);
+  });
+
+  test(".env.worktree contains stable variables for node-basic on main", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath, ["--refresh-env"]);
+
+    const env = await readGeneratedFile(repo.repoPath, ".env.worktree");
+
+    // Project name and schema are deterministic: ${project}-${branch_safe}
+    expect(env).toContain("COMPOSE_PROJECT_NAME=node-basic-main");
+    expect(env).toContain("DB_SCHEMA=node-basic_main");
+
+    // Port keys must be present; values are auto-allocated integers
+    expect(env).toMatch(/^WEB_PORT=\d+$/m);
+    expect(env).toMatch(/^API_PORT=\d+$/m);
+    expect(env).toMatch(/^DB_PORT=\d+$/m);
+  });
+
+  test("grove doctor reports .env.worktree present after --refresh-env", async () => {
+    repo = await createTempExampleRepo("node-basic");
+    await runGroveSetup(repo.repoPath, ["--refresh-env"]);
+
+    const doctor = await runGroveDoctor(repo.repoPath, ["--json"]);
+    expect(doctor.exitCode).toBe(0);
+
+    const result = JSON.parse(doctor.stdout) as {
+      ok: boolean;
+      checks: { name: string; ok: boolean }[];
+    };
+    const envCheck = result.checks.find((c) => c.name === ".env.worktree exists");
+    expect(envCheck?.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// docker-basic
+// ---------------------------------------------------------------------------
+
+describe("docker-basic example", () => {
+  let repo: TempRepo | undefined;
+
+  afterEach(async () => {
+    await repo?.cleanup();
+    repo = undefined;
+  });
+
+  test("grove setup exits 0 and creates .grove/config.json", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+
+    const setup = await runGroveSetup(repo.repoPath);
+    expect(setup.exitCode).toBe(0);
+    expect(existsSync(`${repo.repoPath}/.grove/config.json`)).toBe(true);
+  });
+
+  test("generated config selects docker preset with web service", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const raw = await readGeneratedFile(repo.repoPath, ".grove/config.json");
+    const config = JSON.parse(raw);
+
+    expect(config.enabled).toBe(true);
+    expect(config.project).toBe("docker-basic");
+    expect(config.providers.web.type).toBe("docker-compose");
+    expect(config.providers.web.service).toBe("web");
+    expect(config.naming).toBeDefined();
+    expect(config.naming.composeProject).toBe("${project}-${branch_safe}");
+  });
+
+  test("generated config matches expected snapshot", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const generated = JSON.parse(
+      await readGeneratedFile(repo.repoPath, ".grove/config.json"),
+    );
+    const expected = JSON.parse(
+      await readExpectedFile("docker-basic", ".grove/config.json"),
+    );
+
+    expect(generated).toEqual(expected);
+  });
+
+  test("grove doctor passes after setup", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const doctor = await runGroveDoctor(repo.repoPath);
+    expect(doctor.exitCode).toBe(0);
+    expect(doctor.stdout).toContain("Git repository detected");
+    expect(doctor.stdout).toContain(".grove directory exists");
+    expect(doctor.stdout).toContain("config.json exists");
+  });
+
+  test("grove doctor --json returns structured success output", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath);
+
+    const doctor = await runGroveDoctor(repo.repoPath, ["--json"]);
+    expect(doctor.exitCode).toBe(0);
+
+    const result = JSON.parse(doctor.stdout) as {
+      ok: boolean;
+      checks: { name: string; ok: boolean }[];
+    };
+
+    expect(result.ok).toBe(true);
+    const byName = Object.fromEntries(result.checks.map((c) => [c.name, c.ok]));
+    expect(byName["Git repository detected"]).toBe(true);
+    expect(byName[".grove directory exists"]).toBe(true);
+    expect(byName["config.json exists"]).toBe(true);
+  });
+
+  test("grove setup --refresh-env generates .env.worktree", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath, ["--refresh-env"]);
+
+    expect(existsSync(`${repo.repoPath}/.env.worktree`)).toBe(true);
+  });
+
+  test(".env.worktree contains stable variables for docker-basic on main", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath, ["--refresh-env"]);
+
+    const env = await readGeneratedFile(repo.repoPath, ".env.worktree");
+
+    // Project name and schema are deterministic: ${project}-${branch_safe}
+    expect(env).toContain("COMPOSE_PROJECT_NAME=docker-basic-main");
+    expect(env).toContain("DB_SCHEMA=docker-basic_main");
+
+    // Port keys must be present; values are auto-allocated integers
+    expect(env).toMatch(/^WEB_PORT=\d+$/m);
+    expect(env).toMatch(/^API_PORT=\d+$/m);
+    expect(env).toMatch(/^DB_PORT=\d+$/m);
+  });
+
+  test("grove doctor reports .env.worktree present after --refresh-env", async () => {
+    repo = await createTempExampleRepo("docker-basic");
+    await runGroveSetup(repo.repoPath, ["--refresh-env"]);
+
+    const doctor = await runGroveDoctor(repo.repoPath, ["--json"]);
+    expect(doctor.exitCode).toBe(0);
+
+    const result = JSON.parse(doctor.stdout) as {
+      ok: boolean;
+      checks: { name: string; ok: boolean }[];
+    };
+    const envCheck = result.checks.find((c) => c.name === ".env.worktree exists");
+    expect(envCheck?.ok).toBe(true);
+  });
+});

--- a/tests/e2e/examples.spec.ts
+++ b/tests/e2e/examples.spec.ts
@@ -36,7 +36,9 @@ describe("node-basic example", () => {
 
     const setup = await runGroveSetup(repo.repoPath);
     expect(setup.exitCode).toBe(0);
-    expect(existsSync(path.join(repo.repoPath, ".grove", "config.json"))).toBe(true);
+    expect(existsSync(path.join(repo.repoPath, ".grove", "config.json"))).toBe(
+      true,
+    );
   });
 
   test("generated config has correct project and provider shape", async () => {
@@ -167,7 +169,9 @@ describe("docker-basic example", () => {
 
     const setup = await runGroveSetup(repo.repoPath);
     expect(setup.exitCode).toBe(0);
-    expect(existsSync(path.join(repo.repoPath, ".grove", "config.json"))).toBe(true);
+    expect(existsSync(path.join(repo.repoPath, ".grove", "config.json"))).toBe(
+      true,
+    );
   });
 
   test("generated config selects docker preset with web service", async () => {

--- a/tests/e2e/examples.spec.ts
+++ b/tests/e2e/examples.spec.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, afterEach, beforeAll } from "vitest";
 import { existsSync } from "fs";
+import path from "path";
 import {
   CLI_BIN,
   createTempExampleRepo,
@@ -35,7 +36,7 @@ describe("node-basic example", () => {
 
     const setup = await runGroveSetup(repo.repoPath);
     expect(setup.exitCode).toBe(0);
-    expect(existsSync(`${repo.repoPath}/.grove/config.json`)).toBe(true);
+    expect(existsSync(path.join(repo.repoPath, ".grove", "config.json"))).toBe(true);
   });
 
   test("generated config has correct project and provider shape", async () => {
@@ -112,7 +113,7 @@ describe("node-basic example", () => {
     repo = await createTempExampleRepo("node-basic");
     await runGroveSetup(repo.repoPath, ["--refresh-env"]);
 
-    expect(existsSync(`${repo.repoPath}/.env.worktree`)).toBe(true);
+    expect(existsSync(path.join(repo.repoPath, ".env.worktree"))).toBe(true);
   });
 
   test(".env.worktree contains stable variables for node-basic on main", async () => {
@@ -166,7 +167,7 @@ describe("docker-basic example", () => {
 
     const setup = await runGroveSetup(repo.repoPath);
     expect(setup.exitCode).toBe(0);
-    expect(existsSync(`${repo.repoPath}/.grove/config.json`)).toBe(true);
+    expect(existsSync(path.join(repo.repoPath, ".grove", "config.json"))).toBe(true);
   });
 
   test("generated config selects docker preset with web service", async () => {
@@ -232,7 +233,7 @@ describe("docker-basic example", () => {
     repo = await createTempExampleRepo("docker-basic");
     await runGroveSetup(repo.repoPath, ["--refresh-env"]);
 
-    expect(existsSync(`${repo.repoPath}/.env.worktree`)).toBe(true);
+    expect(existsSync(path.join(repo.repoPath, ".env.worktree"))).toBe(true);
   });
 
   test(".env.worktree contains stable variables for docker-basic on main", async () => {

--- a/tests/e2e/examples.spec.ts
+++ b/tests/e2e/examples.spec.ts
@@ -59,7 +59,7 @@ describe("node-basic example", () => {
       await readGeneratedFile(repo.repoPath, ".grove/config.json"),
     );
     const expected = JSON.parse(
-      await readExpectedFile("node-basic", ".grove/config.json"),
+      await readExpectedFile("node-basic", "grove.config.json"),
     );
 
     expect(generated).toEqual(expected);
@@ -192,7 +192,7 @@ describe("docker-basic example", () => {
       await readGeneratedFile(repo.repoPath, ".grove/config.json"),
     );
     const expected = JSON.parse(
-      await readExpectedFile("docker-basic", ".grove/config.json"),
+      await readExpectedFile("docker-basic", "grove.config.json"),
     );
 
     expect(generated).toEqual(expected);

--- a/tests/e2e/examples.spec.ts
+++ b/tests/e2e/examples.spec.ts
@@ -142,7 +142,9 @@ describe("node-basic example", () => {
       ok: boolean;
       checks: { name: string; ok: boolean }[];
     };
-    const envCheck = result.checks.find((c) => c.name === ".env.worktree exists");
+    const envCheck = result.checks.find(
+      (c) => c.name === ".env.worktree exists",
+    );
     expect(envCheck?.ok).toBe(true);
   });
 });
@@ -260,7 +262,9 @@ describe("docker-basic example", () => {
       ok: boolean;
       checks: { name: string; ok: boolean }[];
     };
-    const envCheck = result.checks.find((c) => c.name === ".env.worktree exists");
+    const envCheck = result.checks.find(
+      (c) => c.name === ".env.worktree exists",
+    );
     expect(envCheck?.ok).toBe(true);
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -54,33 +54,13 @@ export async function createTempExampleRepo(
   };
 }
 
-export async function runGroveSetup(
+async function runGroveCli(
   repoPath: string,
+  command: string,
   extraArgs: string[] = [],
 ): Promise<CliResult> {
   try {
-    const result = await execa(
-      "node",
-      [CLI_BIN, "setup", "--yes", ...extraArgs],
-      { cwd: repoPath },
-    );
-    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
-  } catch (err: unknown) {
-    const e = err as { stdout?: string; stderr?: string; exitCode?: number };
-    return {
-      stdout: e.stdout ?? "",
-      stderr: e.stderr ?? "",
-      exitCode: e.exitCode ?? 1,
-    };
-  }
-}
-
-export async function runGroveDoctor(
-  repoPath: string,
-  extraArgs: string[] = [],
-): Promise<CliResult> {
-  try {
-    const result = await execa("node", [CLI_BIN, "doctor", ...extraArgs], {
+    const result = await execa("node", [CLI_BIN, command, ...extraArgs], {
       cwd: repoPath,
     });
     return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
@@ -92,6 +72,20 @@ export async function runGroveDoctor(
       exitCode: e.exitCode ?? 1,
     };
   }
+}
+
+export function runGroveSetup(
+  repoPath: string,
+  extraArgs: string[] = [],
+): Promise<CliResult> {
+  return runGroveCli(repoPath, "setup", ["--yes", ...extraArgs]);
+}
+
+export function runGroveDoctor(
+  repoPath: string,
+  extraArgs: string[] = [],
+): Promise<CliResult> {
+  return runGroveCli(repoPath, "doctor", extraArgs);
 }
 
 export async function readGeneratedFile(

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,112 @@
+import { cp, mkdir, mkdtemp, rm, readFile } from "fs/promises";
+import path from "path";
+import os from "os";
+import { execa } from "execa";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+const EXAMPLES_DIR = path.join(PROJECT_ROOT, "examples");
+export const CLI_BIN = path.join(PROJECT_ROOT, "dist", "index.js");
+
+export interface TempRepo {
+  repoPath: string;
+  cleanup: () => Promise<void>;
+}
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Copy an example template into a temp directory whose basename matches the
+ * example name (so `detectProject` derives a predictable project name), then
+ * initialise it as a git repo on branch `main`.
+ */
+export async function createTempExampleRepo(
+  exampleName: string,
+): Promise<TempRepo> {
+  const parentDir = await mkdtemp(path.join(os.tmpdir(), "grove-e2e-"));
+  const repoPath = path.join(parentDir, exampleName);
+  await mkdir(repoPath);
+
+  const templateDir = path.join(EXAMPLES_DIR, exampleName, "template");
+  await cp(templateDir, repoPath, { recursive: true });
+
+  await execa("git", ["init"], { cwd: repoPath });
+  // Set HEAD to main without requiring the branch to exist yet
+  await execa("git", ["symbolic-ref", "HEAD", "refs/heads/main"], {
+    cwd: repoPath,
+  });
+  await execa("git", ["config", "user.email", "test@grove.local"], {
+    cwd: repoPath,
+  });
+  await execa("git", ["config", "user.name", "Grove Test"], { cwd: repoPath });
+  await execa("git", ["add", "-A"], { cwd: repoPath });
+  await execa("git", ["commit", "-m", "initial commit"], { cwd: repoPath });
+
+  return {
+    repoPath,
+    cleanup: () => rm(parentDir, { recursive: true, force: true }),
+  };
+}
+
+export async function runGroveSetup(
+  repoPath: string,
+  extraArgs: string[] = [],
+): Promise<CliResult> {
+  try {
+    const result = await execa(
+      "node",
+      [CLI_BIN, "setup", "--yes", ...extraArgs],
+      { cwd: repoPath },
+    );
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; exitCode?: number };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.exitCode ?? 1,
+    };
+  }
+}
+
+export async function runGroveDoctor(
+  repoPath: string,
+  extraArgs: string[] = [],
+): Promise<CliResult> {
+  try {
+    const result = await execa("node", [CLI_BIN, "doctor", ...extraArgs], {
+      cwd: repoPath,
+    });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; exitCode?: number };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.exitCode ?? 1,
+    };
+  }
+}
+
+export async function readGeneratedFile(
+  repoPath: string,
+  relPath: string,
+): Promise<string> {
+  return readFile(path.join(repoPath, relPath), "utf-8");
+}
+
+export async function readExpectedFile(
+  exampleName: string,
+  relPath: string,
+): Promise<string> {
+  return readFile(
+    path.join(EXAMPLES_DIR, exampleName, "expected", relPath),
+    "utf-8",
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    exclude: [...configDefaults.exclude, "tests/e2e/**"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.{ts,tsx}"],

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/e2e/**/*.spec.ts"],
+    testTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
This pull request introduces comprehensive end-to-end (e2e) testing for the example projects, adds a new `doctor` command for diagnostics, and improves the CI pipeline to ensure quality for example templates. The main themes are: new features for diagnostics, robust e2e test coverage for example projects, and associated infrastructure and documentation updates.

**New diagnostics feature:**

* Added a new `doctor` command (`runDoctor` in `doctor.ts`) that checks repository health, `.grove` directory and config, `.env.worktree`, and git worktree state, with both human-readable and `--json` output. This command exits nonzero if any required check fails. (`[[1]](diffhunk://#diff-419923946fc8b0a1c480a93916199fd1adf808aa692c933dfb4e2fa538502450R1-R148)`, `[[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R27)`, `[[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R923-R928)`)

**End-to-end test suite for examples:**

* Added e2e tests (`examples.spec.ts`) that verify `grove setup`, `grove doctor`, and generated files for both `node-basic` and `docker-basic` example projects. These tests cover successful setup, config snapshots, diagnostics, and presence of environment files. (`[tests/e2e/examples.spec.tsR1-R266](diffhunk://#diff-92301bc92011f49c20f442814655c6b70b11b5707bccb566465fb65ac5588878R1-R266)`)
* Created e2e test helpers (`helpers.ts`) for setting up isolated git repos from example templates, running CLI commands, and reading generated/expected files. (`[tests/e2e/helpers.tsR1-R112](diffhunk://#diff-09b5dbc3294cf8082fb811f02ee92cafaefd684983adb1d686f0ad2450c6fe58R1-R112)`)
* Added a dedicated Vitest config for e2e tests (`vitest.e2e.config.ts`) and updated the main config to exclude e2e tests from the default suite. (`[[1]](diffhunk://#diff-e0cf55d9d9c01b1f776dd0d75a31d676058de2f05ab5f7750f792b3dd676d768R1-R10)`, `[[2]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92L1-R9)`)

**Continuous Integration and scripts:**

* Updated the CI workflow to run e2e tests after the main test suite, ensuring examples remain functional. (`[.github/workflows/ci.ymlR29-R31](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR29-R31)`)
* Added a new `test:e2e` script to `package.json` for running e2e tests. (`[package.jsonL14-R15](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R15)`)

**New and improved example templates:**

* Added a minimal `docker-basic` example template with `docker-compose.yml` and `package.json`, plus usage documentation. (`[[1]](diffhunk://#diff-4475f0be13b6a5d4cbe513c0727aa8dc0c706df25d3c60f3fa5b20b5276203c1R1-R8)`, `[[2]](diffhunk://#diff-a48ff63e04edd7eced81c4e7d7f8d67162952dcd46c7ebc6f7d9d7eaf3241e6cR1-R5)`, `[[3]](diffhunk://#diff-24895b130519497e43dab343ed87a2782d7a1b2cc10d91ba7ad8196e6b706781R1-R10)`)
* Improved the `node-basic` example template with a `package.json` including scripts and a usage README. (`[[1]](diffhunk://#diff-63bf82433c08fe6272ce527926d2f20237d4e3eb32b41b77f564883d08ae29e9R1-R9)`, `[[2]](diffhunk://#diff-a47a8d470223c37b7b37017413fd4fa5ba2ea299dd6255a50630ce475fc860ccR1-R10)`)