### PR TITLE
Chore/more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ grove        # open TUI in any repo with worktrees
 
 ---
 
+## The core idea
+
+Grove's job is simple: for each branch, it writes a `.env.worktree` file with unique values — a different port, a different Docker project name, a different database schema. Your `docker-compose.yml` reads these variables. Each branch gets a completely isolated stack. No manual port tracking, no coordination between terminals.
+
+```bash
+# .env.worktree generated for feat/login
+COMPOSE_PROJECT_NAME=my-app-feat-login
+WEB_PORT=8081
+DB_PORT=5433
+DB_SCHEMA=my_app_feat_login
+
+# .env.worktree generated for feat/payments (running in parallel)
+COMPOSE_PROJECT_NAME=my-app-feat-payments
+WEB_PORT=8083
+DB_PORT=5435
+DB_SCHEMA=my_app_feat_payments
+```
+
+Normally Grove hands these files straight to `docker compose --env-file`. If your startup needs more — waiting for a DB healthcheck, running migrations, seeding fixture data on first boot — a [custom startup script](https://christinabranson.github.io/git-grove/guides/docker#custom-startup-scripts) lets you take over while still receiving all the generated env vars.
+
+---
+
 ## Why Grove?
 
 Git worktrees are powerful — you can have multiple branches checked out simultaneously, each in its own directory. But the experience is rough. You manage paths manually, ports collide between stacks, and there's no way to see what's running where.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
         items: [
           { text: "Node Project", link: "/examples/node-script" },
           { text: "Docker Compose", link: "/examples/docker" },
+          { text: "Docker + Custom Script", link: "/examples/docker-script" },
           { text: "Kubernetes Dev", link: "/examples/kubernetes" },
         ],
       },

--- a/docs/examples/docker-script.md
+++ b/docs/examples/docker-script.md
@@ -1,0 +1,224 @@
+# Example: Docker + Custom Script
+
+A walkthrough of using Grove's `custom-shell` provider to run a shell script as the startup sequence — useful when `docker compose up` alone is not enough.
+
+**Use this pattern when you need to:**
+
+- Wait for a database healthcheck before starting the application
+- Run per-worktree migrations or schema creation on first boot
+- Execute any pre/post startup logic that belongs with the project
+
+## Project structure
+
+```
+my-app/
+├── docker-compose.yml     # web + db services
+├── bin/
+│   ├── start.sh           # Grove calls this on grove start
+│   └── stop.sh            # Grove calls this on grove stop
+└── .grove/
+    └── config.json        # committed
+```
+
+## Config
+
+**`.grove/config.json`:**
+
+```json
+{
+  "project": "docker-script",
+  "providers": {
+    "web": {
+      "type": "custom-shell",
+      "service": "web",
+      "script": "bin/start.sh",
+      "stopScript": "bin/stop.sh"
+    }
+  },
+  "naming": {
+    "composeProject": "${project}-${branch_safe}",
+    "dbSchema": "${project}_${branch_safe}",
+    "ports": {
+      "WEB_PORT": "auto",
+      "DB_PORT": "auto"
+    }
+  },
+  "worktrees": {
+    "prefix": "grove",
+    "defaultBaseBranch": "main"
+  }
+}
+```
+
+**`docker-compose.yml`:**
+
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${DB_SCHEMA:-app}
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app"]
+      interval: 2s
+      retries: 10
+
+  web:
+    image: node:18-alpine
+    working_dir: /app
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    environment:
+      DATABASE_URL: postgres://app:app@db:5432/${DB_SCHEMA:-app}
+```
+
+**`bin/start.sh`:**
+
+```bash
+#!/usr/bin/env bash
+# Grove injects all .env.worktree variables into the environment before
+# calling this script, so $COMPOSE_PROJECT_NAME, $WEB_PORT, $DB_SCHEMA,
+# etc. are all available without any sourcing.
+# GROVE_ENV_FILE points at the .env.worktree file itself — pass it to
+# docker compose with --env-file so Compose sees the same values.
+set -euo pipefail
+
+COMPOSE_FLAGS=(-p "$COMPOSE_PROJECT_NAME" --env-file "$GROVE_ENV_FILE")
+
+echo "==> Starting infrastructure for project: $COMPOSE_PROJECT_NAME"
+
+# Bring up the database and wait for its healthcheck.
+docker compose "${COMPOSE_FLAGS[@]}" up -d db
+echo "==> Waiting for postgres to be healthy..."
+docker compose "${COMPOSE_FLAGS[@]}" wait db
+
+# Seed the per-worktree schema once, on first boot.
+SEED_MARKER=".grove/.seeded-${COMPOSE_PROJECT_NAME}"
+if [[ ! -f "$SEED_MARKER" ]]; then
+  echo "==> Creating schema: $DB_SCHEMA"
+  docker compose "${COMPOSE_FLAGS[@]}" exec -T db \
+    psql -U app -c "CREATE SCHEMA IF NOT EXISTS \"$DB_SCHEMA\";"
+  touch "$SEED_MARKER"
+fi
+
+# Start the application.
+docker compose "${COMPOSE_FLAGS[@]}" up -d --build web
+
+echo "==> Environment ready at http://localhost:${WEB_PORT}"
+```
+
+**`bin/stop.sh`:**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -p "$COMPOSE_PROJECT_NAME" --env-file "$GROVE_ENV_FILE" down
+```
+
+## How Grove calls your scripts
+
+When you run `grove start <branch>`, Grove:
+
+1. Creates (or attaches) the worktree.
+2. Generates `.env.worktree` from naming templates — unique ports, compose project name, db schema, etc.
+3. Parses `.env.worktree` and injects every key=value pair into the script's environment.
+4. Sets `GROVE_ENV_FILE=<path>/.env.worktree` as an additional variable.
+5. Runs `bin/start.sh` with `cwd` set to the worktree root.
+
+`grove stop` calls `bin/stop.sh` the same way. If `stopScript` is absent from the config, Grove falls back to `docker compose -p $COMPOSE_PROJECT_NAME down`.
+
+## Workflow
+
+### Start a feature branch
+
+```bash
+grove start feat/login --new
+```
+
+```
+Creating worktree at ~/repos/my-app-worktrees/feat-login…
+  branching off main
+Generating .env.worktree from grove config…
+  COMPOSE_PROJECT_NAME=docker-script-feat-login
+  WEB_PORT=8081
+  DB_PORT=5433
+  DB_SCHEMA=docker_script_feat_login
+Resolving environment provider…
+  → provider: custom-shell  (bin/start.sh)
+Starting environment…
+==> Starting infrastructure for project: docker-script-feat-login
+==> Waiting for postgres to be healthy...
+==> Creating schema: docker_script_feat_login
+==> Environment ready at http://localhost:8081
+  web: http://localhost:8081
+  source: grove
+✓ Ready: feat/login
+```
+
+### Start a second branch in parallel
+
+```bash
+grove start feat/payments --new
+```
+
+```
+COMPOSE_PROJECT_NAME=docker-script-feat-payments
+WEB_PORT=8083
+DB_PORT=5435
+DB_SCHEMA=docker_script_feat_payments
+```
+
+Both environments run simultaneously with no port conflicts and isolated schemas.
+
+### Check status
+
+```bash
+grove status
+```
+
+```
+  branch           provider       web     db schema
+  feat/login       custom-shell   :8081   docker_script_feat_login
+  feat/payments    custom-shell   :8083   docker_script_feat_payments
+  main             —              —       —
+```
+
+### Tear down
+
+```bash
+grove delete feat/login
+```
+
+Calls `bin/stop.sh` (which runs `docker compose down`), then removes the worktree directory.
+
+## Variables available in your scripts
+
+All variables written to `.env.worktree` are injected, plus `GROVE_ENV_FILE`:
+
+| Variable               | Example value                                   |
+| ---------------------- | ----------------------------------------------- |
+| `COMPOSE_PROJECT_NAME` | `docker-script-feat-login`                      |
+| `WEB_PORT`             | `8081`                                          |
+| `DB_PORT`              | `5433`                                          |
+| `DB_SCHEMA`            | `docker_script_feat_login`                      |
+| `GROVE_ENV_FILE`       | `/home/user/worktrees/feat-login/.env.worktree` |
+
+Any variables from `naming.ports`, `envContract.passthrough`, and `envContract.derived` are also present.
+
+## Compared to the `docker-compose` provider
+
+| Behavior                   | `docker-compose`         | `custom-shell`                      |
+| -------------------------- | ------------------------ | ----------------------------------- |
+| Who calls `docker compose` | Grove                    | Your script                         |
+| Pre-start hooks            | Not supported            | Anything you put in the script      |
+| Post-start hooks           | Not supported            | Anything you put in the script      |
+| `grove status` check       | `docker compose ps`      | `docker compose ps` (same)          |
+| Stop behavior              | `docker compose down`    | Your stop script (or same fallback) |
+| `.env.worktree` generation | Grove (naming templates) | Grove (naming templates) — same     |

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -29,9 +29,10 @@ A **provider** is how Grove starts and stops a worktree's development environmen
 | ---------------- | --------------------------------------------------------------------- |
 | `docker-compose` | `docker-compose.yml` or `compose.yaml` exists + `.env.worktree` found |
 | `node-scripts`   | `package.json` has a `dev` or `start` script                          |
+| `custom-shell`   | Configured explicitly in `.grove/config.json`                         |
 | `unknown`        | No recognized project type — Grove takes no destructive action        |
 
-You can also configure providers explicitly in `.grove/config.json` to skip auto-detection.
+You can also configure providers explicitly in `.grove/config.json` to skip auto-detection. The `custom-shell` provider is always explicit — it never auto-detects — and lets you run any shell script as the startup sequence (see [Custom startup scripts](/guides/docker#custom-startup-scripts)).
 
 ## `.env.worktree`
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -43,7 +43,7 @@ grove start feat/my-feature --new
 grove start 1234
 ```
 
-Grove creates the worktree, generates `.env.worktree` with unique ports (if configured), starts the shared stack, and boots the environment.
+Grove creates the worktree, then generates a `.env.worktree` file with unique values for this branch — a different port, Docker project name, and database schema from every other worktree. Your `docker-compose.yml` reads these variables, so each branch gets a completely isolated stack with no manual port tracking.
 
 Expected output for a Docker project:
 

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -187,6 +187,103 @@ grove doctor env feat/my-feature
 
 `grove doctor env` shows expected variables, detected port references, and any mismatches.
 
+## Custom startup scripts
+
+Sometimes `docker compose up` is not enough. If your startup sequence needs steps that plain Compose cannot express — waiting for a database to be healthy, running per-worktree schema migrations, seeding fixture data on first boot — use the `custom-shell` provider.
+
+### How it works
+
+Grove still generates `.env.worktree` exactly as it would for a `docker-compose` project. Instead of calling `docker compose up` itself, it:
+
+1. Parses `.env.worktree` and injects every variable into the script's environment.
+2. Sets `GROVE_ENV_FILE=<worktree-path>/.env.worktree` so the script can forward the file to `docker compose --env-file "$GROVE_ENV_FILE"`.
+3. Runs your script with `cwd` set to the worktree root.
+
+Your script is responsible for the actual `docker compose up` call and any surrounding logic.
+
+### Config
+
+```json
+{
+  "project": "my-app",
+  "providers": {
+    "web": {
+      "type": "custom-shell",
+      "service": "web",
+      "script": "bin/start.sh",
+      "stopScript": "bin/stop.sh"
+    }
+  },
+  "naming": {
+    "composeProject": "${project}-${branch_safe}",
+    "dbSchema": "${project}_${branch_safe}",
+    "ports": {
+      "WEB_PORT": "auto",
+      "DB_PORT": "auto"
+    }
+  }
+}
+```
+
+| Field        | Required | Description                                                                   |
+| ------------ | -------- | ----------------------------------------------------------------------------- |
+| `script`     | yes      | Path to the startup script, relative to the worktree root                     |
+| `stopScript` | no       | Path to the teardown script. Falls back to `docker compose down` when absent. |
+| `service`    | no       | Compose service name used by `grove status` to check the running state        |
+
+### Writing the script
+
+All `.env.worktree` variables are already in the environment when the script runs. You do not need to `source` the file — though you can pass it to `docker compose` via `$GROVE_ENV_FILE`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FLAGS=(-p "$COMPOSE_PROJECT_NAME" --env-file "$GROVE_ENV_FILE")
+
+# Start the database and wait for its healthcheck.
+docker compose "${COMPOSE_FLAGS[@]}" up -d db
+docker compose "${COMPOSE_FLAGS[@]}" wait db
+
+# Run migrations once per worktree.
+SEED_MARKER=".grove/.seeded-${COMPOSE_PROJECT_NAME}"
+if [[ ! -f "$SEED_MARKER" ]]; then
+  docker compose "${COMPOSE_FLAGS[@]}" run --rm db \
+    psql -U app -c "CREATE SCHEMA IF NOT EXISTS \"$DB_SCHEMA\";"
+  touch "$SEED_MARKER"
+fi
+
+# Bring up the application.
+docker compose "${COMPOSE_FLAGS[@]}" up -d --build web
+echo "Ready at http://localhost:${WEB_PORT}"
+```
+
+Variables always available in the script:
+
+| Variable               | Example value                                   |
+| ---------------------- | ----------------------------------------------- |
+| `COMPOSE_PROJECT_NAME` | `my-app-feat-login`                             |
+| `WEB_PORT`             | `8081`                                          |
+| `DB_PORT`              | `5433`                                          |
+| `DB_SCHEMA`            | `my_app_feat_login`                             |
+| `GROVE_ENV_FILE`       | `/home/user/worktrees/feat-login/.env.worktree` |
+
+Any additional variables from `naming.ports` or `envContract.passthrough` / `envContract.derived` are also present.
+
+### Stop script
+
+If `stopScript` is omitted, `grove stop` falls back to `docker compose -p $COMPOSE_PROJECT_NAME down`. Provide a stop script when you need custom teardown:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -p "$COMPOSE_PROJECT_NAME" --env-file "$GROVE_ENV_FILE" down
+```
+
+### Full example
+
+See the [Docker Script example](/examples/docker-script) for a complete project using this pattern.
+
 ## Docker commands
 
 ```bash

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -229,7 +229,7 @@ Your script is responsible for the actual `docker compose up` call and any surro
 | ------------ | -------- | ----------------------------------------------------------------------------- |
 | `script`     | yes      | Path to the startup script, relative to the worktree root                     |
 | `stopScript` | no       | Path to the teardown script. Falls back to `docker compose down` when absent. |
-| `service`    | no       | Compose service name used by `grove status` to check the running state        |
+| `service`    | no       | Reserved — not currently used by the runtime                                  |
 
 ### Writing the script
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ hero:
       link: https://github.com/christinabranson/git-grove
 
 features:
-  - title: Parallel environments
-    details: Each branch gets its own isolated environment — its own Docker stack, unique ports, and database schema. Run as many as you need simultaneously.
+  - title: Isolated environments
+    details: "For each branch, Grove writes a `.env.worktree` file with unique values: a different port, a different Docker project name, a different schema. Your Compose file reads them — each branch gets its own stack. No coordination needed."
   - title: AI agent-ready
     details: Agents discover their environment via `grove status --json` and report status back via `.worktree-manifest.json`. Grove displays it live in the TUI.
   - title: Zero lock-in

--- a/examples/docker-script/expected/grove.config.json
+++ b/examples/docker-script/expected/grove.config.json
@@ -1,0 +1,24 @@
+{
+  "enabled": true,
+  "project": "docker-script",
+  "providers": {
+    "web": {
+      "type": "custom-shell",
+      "service": "web",
+      "script": "bin/start.sh",
+      "stopScript": "bin/stop.sh"
+    }
+  },
+  "naming": {
+    "composeProject": "${project}-${branch_safe}",
+    "dbSchema": "${project}_${branch_safe}",
+    "ports": {
+      "WEB_PORT": "auto",
+      "DB_PORT": "auto"
+    }
+  },
+  "worktrees": {
+    "prefix": "grove",
+    "defaultBaseBranch": "main"
+  }
+}

--- a/examples/docker-script/template/README.md
+++ b/examples/docker-script/template/README.md
@@ -1,0 +1,48 @@
+# docker-script
+
+A Docker Compose project that uses a custom shell script to orchestrate startup.
+Grove generates `.env.worktree` as usual, then delegates `grove start` to
+`bin/start.sh` instead of calling `docker compose up` directly.
+
+## Why a custom script?
+
+Use this pattern when your startup sequence needs steps that plain
+`docker compose up` cannot express:
+
+- waiting for a dependency to be healthy before running migrations
+- seeding a per-worktree database schema on first boot
+- any pre/post startup logic that belongs with the project, not in CI
+
+## How it works
+
+`.grove/config.json` declares the `custom-shell` provider:
+
+```json
+{
+  "providers": {
+    "web": {
+      "type": "custom-shell",
+      "service": "web",
+      "script": "bin/start.sh",
+      "stopScript": "bin/stop.sh"
+    }
+  }
+}
+```
+
+When you run `grove start <branch>`, grove:
+
+1. Creates the worktree and writes `.env.worktree` with per-worktree values
+   (`COMPOSE_PROJECT_NAME`, `WEB_PORT`, `DB_PORT`, `DB_SCHEMA`, …).
+2. Invokes `bin/start.sh` with those variables already in the environment.
+3. Also sets `GROVE_ENV_FILE=<path>/.env.worktree` so the script can pass the
+   file to `docker compose --env-file "$GROVE_ENV_FILE"`.
+
+`grove stop` calls `bin/stop.sh` the same way.
+
+## Usage
+
+```bash
+grove setup          # writes .grove/config.json
+grove start feature/my-branch
+```

--- a/examples/docker-script/template/bin/start.sh
+++ b/examples/docker-script/template/bin/start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Grove invokes this script with all .env.worktree variables already present in
+# the environment, plus GROVE_ENV_FILE pointing at the file itself so you can
+# pass it to docker compose with --env-file.
+set -euo pipefail
+
+COMPOSE_FLAGS=(-p "$COMPOSE_PROJECT_NAME" --env-file "$GROVE_ENV_FILE")
+
+echo "==> Starting infrastructure for project: $COMPOSE_PROJECT_NAME"
+
+# Bring up the DB first and wait for its healthcheck to pass.
+docker compose "${COMPOSE_FLAGS[@]}" up -d db
+echo "==> Waiting for postgres to be healthy..."
+docker compose "${COMPOSE_FLAGS[@]}" wait db 2>/dev/null || \
+  docker compose "${COMPOSE_FLAGS[@]}" run --rm db \
+    sh -c 'until pg_isready -U app; do sleep 1; done'
+
+# Run any one-time seed / migration work here.
+# (This block is skipped when the schema already exists.)
+SEED_MARKER=".grove/.seeded-${COMPOSE_PROJECT_NAME}"
+if [[ ! -f "$SEED_MARKER" ]]; then
+  echo "==> Seeding database schema: $DB_SCHEMA"
+  docker compose "${COMPOSE_FLAGS[@]}" exec -T db \
+    psql -U app -c "CREATE SCHEMA IF NOT EXISTS \"$DB_SCHEMA\";" 2>/dev/null || true
+  touch "$SEED_MARKER"
+fi
+
+# Start the rest of the services.
+docker compose "${COMPOSE_FLAGS[@]}" up -d --build web
+
+echo "==> Environment ready at http://localhost:${WEB_PORT}"

--- a/examples/docker-script/template/bin/stop.sh
+++ b/examples/docker-script/template/bin/stop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FLAGS=(-p "$COMPOSE_PROJECT_NAME" --env-file "$GROVE_ENV_FILE")
+
+echo "==> Stopping project: $COMPOSE_PROJECT_NAME"
+docker compose "${COMPOSE_FLAGS[@]}" down

--- a/examples/docker-script/template/docker-compose.yml
+++ b/examples/docker-script/template/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${DB_SCHEMA:-app}
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  web:
+    image: node:18-alpine
+    working_dir: /app
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    environment:
+      - NODE_ENV=development
+      - DATABASE_URL=postgres://app:app@db:5432/${DB_SCHEMA:-app}
+    command: >
+      node -e "
+        const http = require('http');
+        const db = process.env.DATABASE_URL;
+        http.createServer((_, r) => r.end('docker-script env=' + process.env.NODE_ENV + ' db=' + db + '\n')).listen(3000, () => console.log('listening on 3000'));
+      "

--- a/src/providers/custom-shell.ts
+++ b/src/providers/custom-shell.ts
@@ -1,0 +1,180 @@
+import { execa } from "execa";
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import type { GroveProvider } from "./types.js";
+import type { GroveEnvironment } from "../types.js";
+
+interface EnvWorktreeVars {
+  projectName: string;
+  webPort?: number;
+  apiPort?: number;
+}
+
+async function parseEnvWorktree(
+  worktreePath: string,
+): Promise<{ raw: Record<string, string>; typed: EnvWorktreeVars }> {
+  const envPath = path.join(worktreePath, ".env.worktree");
+  const raw: Record<string, string> = {};
+
+  if (existsSync(envPath)) {
+    const text = await readFile(envPath, "utf-8");
+    for (const line of text.split("\n")) {
+      const match = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (match) raw[match[1]] = match[2];
+    }
+  }
+
+  return {
+    raw,
+    typed: {
+      projectName: raw["COMPOSE_PROJECT_NAME"] ?? path.basename(worktreePath),
+      webPort: raw["WEB_PORT"] ? parseInt(raw["WEB_PORT"], 10) : undefined,
+      apiPort: raw["API_PORT"] ? parseInt(raw["API_PORT"], 10) : undefined,
+    },
+  };
+}
+
+async function getDockerState(
+  projectName: string,
+): Promise<"running" | "partial" | "stopped" | "not started"> {
+  try {
+    const { stdout } = await execa("docker", [
+      "compose",
+      "-p",
+      projectName,
+      "ps",
+      "--format",
+      "json",
+    ]);
+    const containers = stdout
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    if (containers.length === 0) return "not started";
+    const running = containers.filter(
+      (c: Record<string, unknown>) => c["State"] === "running",
+    ).length;
+    if (running === containers.length) return "running";
+    if (running > 0) return "partial";
+    return "stopped";
+  } catch {
+    return "not started";
+  }
+}
+
+export class CustomShellProvider implements GroveProvider {
+  readonly name = "custom-shell";
+
+  constructor(
+    private readonly worktreePath: string,
+    private readonly envName: string,
+    private readonly script: string,
+    private readonly stopScript?: string,
+    private readonly serviceOverride?: string,
+  ) {}
+
+  async start(): Promise<GroveEnvironment> {
+    const scriptPath = path.resolve(this.worktreePath, this.script);
+    if (!existsSync(scriptPath)) {
+      throw new Error(`Custom start script not found: ${scriptPath}`);
+    }
+
+    const { raw, typed } = await parseEnvWorktree(this.worktreePath);
+
+    // Make the .env.worktree path available so the script can pass it to
+    // docker compose (e.g. docker compose --env-file "$GROVE_ENV_FILE" up)
+    const envForScript: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ...raw,
+      GROVE_ENV_FILE: path.join(this.worktreePath, ".env.worktree"),
+    };
+
+    await execa("bash", [scriptPath], {
+      cwd: this.worktreePath,
+      env: envForScript,
+      stdio: "inherit",
+    });
+
+    return this._buildEnv(typed, "running");
+  }
+
+  async stop(): Promise<void> {
+    const { raw, typed } = await parseEnvWorktree(this.worktreePath);
+
+    if (this.stopScript) {
+      const stopPath = path.resolve(this.worktreePath, this.stopScript);
+      if (!existsSync(stopPath)) {
+        throw new Error(`Custom stop script not found: ${stopPath}`);
+      }
+
+      const envForScript: Record<string, string> = {
+        ...(process.env as Record<string, string>),
+        ...raw,
+        GROVE_ENV_FILE: path.join(this.worktreePath, ".env.worktree"),
+      };
+
+      await execa("bash", [stopPath], {
+        cwd: this.worktreePath,
+        env: envForScript,
+        stdio: "inherit",
+      });
+      return;
+    }
+
+    // Fallback: stop via docker compose if a compose file is present
+    const hasCompose =
+      existsSync(path.join(this.worktreePath, "docker-compose.yml")) ||
+      existsSync(path.join(this.worktreePath, "compose.yml"));
+
+    if (hasCompose) {
+      await execa(
+        "docker",
+        [
+          "compose",
+          "-p",
+          typed.projectName,
+          "--env-file",
+          ".env.worktree",
+          "down",
+        ],
+        { cwd: this.worktreePath },
+      );
+    }
+  }
+
+  async status(): Promise<GroveEnvironment> {
+    const { typed } = await parseEnvWorktree(this.worktreePath);
+    const state = await getDockerState(typed.projectName);
+    return this._buildEnv(typed, state);
+  }
+
+  private _buildEnv(vars: EnvWorktreeVars, _state: string): GroveEnvironment {
+    const env: GroveEnvironment = {
+      name: this.envName,
+      worktreePath: this.worktreePath,
+      metadata: { source: "grove", provider: "custom-shell" },
+    };
+
+    if (vars.webPort) {
+      env.web = { url: `http://localhost:${vars.webPort}`, port: vars.webPort };
+    }
+    if (vars.apiPort) {
+      env.api = {
+        url: `http://localhost:${vars.apiPort}`,
+        port: vars.apiPort,
+      };
+    }
+
+    return env;
+  }
+}

--- a/src/providers/custom-shell.ts
+++ b/src/providers/custom-shell.ts
@@ -83,8 +83,19 @@ export class CustomShellProvider implements GroveProvider {
     private readonly serviceOverride?: string,
   ) {}
 
+  private resolveScript(script: string, label: string): string {
+    const resolved = path.resolve(this.worktreePath, script);
+    if (
+      !resolved.startsWith(this.worktreePath + path.sep) &&
+      resolved !== this.worktreePath
+    ) {
+      throw new Error(`${label} path escapes the worktree root: ${script}`);
+    }
+    return resolved;
+  }
+
   async start(): Promise<GroveEnvironment> {
-    const scriptPath = path.resolve(this.worktreePath, this.script);
+    const scriptPath = this.resolveScript(this.script, "script");
     if (!existsSync(scriptPath)) {
       throw new Error(`Custom start script not found: ${scriptPath}`);
     }
@@ -112,7 +123,7 @@ export class CustomShellProvider implements GroveProvider {
     const { raw, typed } = await parseEnvWorktree(this.worktreePath);
 
     if (this.stopScript) {
-      const stopPath = path.resolve(this.worktreePath, this.stopScript);
+      const stopPath = this.resolveScript(this.stopScript, "stopScript");
       if (!existsSync(stopPath)) {
         throw new Error(`Custom stop script not found: ${stopPath}`);
       }
@@ -131,10 +142,17 @@ export class CustomShellProvider implements GroveProvider {
       return;
     }
 
-    // Fallback: stop via docker compose if a compose file is present
-    const hasCompose =
-      existsSync(path.join(this.worktreePath, "docker-compose.yml")) ||
-      existsSync(path.join(this.worktreePath, "compose.yml"));
+    // Fallback: stop via docker compose if a compose file is present.
+    // Matches the same filename list used by docker-compose-contract.ts.
+    const composeFiles = [
+      "compose.yaml",
+      "compose.yml",
+      "docker-compose.yml",
+      "docker-compose.yaml",
+    ];
+    const hasCompose = composeFiles.some((f) =>
+      existsSync(path.join(this.worktreePath, f)),
+    );
 
     if (hasCompose) {
       await execa(

--- a/src/providers/discover.ts
+++ b/src/providers/discover.ts
@@ -2,6 +2,7 @@ import type { GroveProvider } from "./types.js";
 import type { GroveEnvironment, GroveConfig } from "../types.js";
 import { DockerComposeProvider } from "./docker-compose.js";
 import { NodeScriptsProvider } from "./node-scripts.js";
+import { CustomShellProvider } from "./custom-shell.js";
 import { loadGroveConfig } from "../data/groveConfig.js";
 import { detectProject } from "../setup/detect.js";
 
@@ -100,6 +101,19 @@ function resolveFromConfig(
         worktreePath,
         envName,
         providerConfig.command ?? "dev",
+      );
+    case "custom-shell":
+      if (!providerConfig.script) {
+        throw new Error(
+          `custom-shell provider requires a "script" field in .grove/config.json`,
+        );
+      }
+      return new CustomShellProvider(
+        worktreePath,
+        envName,
+        providerConfig.script,
+        providerConfig.stopScript,
+        providerConfig.service,
       );
     default:
       return new FallbackProvider(worktreePath, envName);

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,10 @@ export interface GroveConfigProvider {
   type: "docker-compose" | "node-scripts" | "custom-shell";
   service?: string;
   command?: string;
+  /** Path to the startup script (relative to worktree root). Required for custom-shell. */
+  script?: string;
+  /** Path to the teardown script (relative to worktree root). Falls back to docker compose down when absent. */
+  stopScript?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface GroveConfigProvider {
   command?: string;
   /** Path to the startup script (relative to worktree root). Required for custom-shell. */
   script?: string;
-  /** Path to the teardown script (relative to worktree root). Falls back to docker compose down when absent. */
+  /** Path to the teardown script (relative to worktree root). Falls back to docker compose down when absent and a compose file is detected. */
   stopScript?: string;
 }
 


### PR DESCRIPTION
This pull request adds support for a new `custom-shell` provider, enabling users to run custom shell scripts for starting and stopping Docker-based environments in Grove. It also provides extensive documentation and an example project to help users adopt this pattern, especially when `docker compose up` alone isn't sufficient (e.g., for database migrations or health checks). The most important changes are:

**Feature: Custom Shell Provider Implementation**
- Added a new `CustomShellProvider` class in `src/providers/custom-shell.ts`, which allows Grove to delegate environment startup and teardown to user-provided shell scripts, injecting all `.env.worktree` variables and supporting both custom and fallback stop logic.

**Documentation: Guides and Examples**
- Added a comprehensive guide at `docs/examples/docker-script.md` and an example project in `examples/docker-script/`, demonstrating how to use the `custom-shell` provider with Docker Compose and custom scripts. [[1]](diffhunk://#diff-92e28cf357fff9863de3b546543f8d8ad1957fd1147404999df33b82d5a86c89R1-R224) [[2]](diffhunk://#diff-7df64706c689ed397ed7570c8938e1f29d3c5beeceb19281e032a5d77d6e3f19R1-R48) [[3]](diffhunk://#diff-857dba3e666df2e9a4b17ef76ae0b346d00d82ccc7222699fff5f0edab96c6deR1-R32) [[4]](diffhunk://#diff-6f983bc22963673affb657846db3b7abb61fbc1a1aafb90b02664f1fb3c935baR1-R24)
- Updated `docs/guides/docker.md` to include a section on custom startup scripts, detailing configuration, environment variables, and script structure.
- Updated `docs/getting-started/concepts.md` to document the `custom-shell` provider and clarify its explicit configuration.
- Improved the quickstart and README to explain the `.env.worktree` concept and how it enables isolated environments per branch. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R53) [[2]](diffhunk://#diff-c82da606fcd93ea4a7bae7c6e599d5c083312a3c53c51526bc925e2b229d5857L46-R46) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L20-R21)

**Documentation Navigation**
- Updated the VitePress config to add the new Docker + Custom Script example to the docs sidebar.