### PR TITLE
Chore/add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump prerelease version
+      - name: Bump prerelease version and tag
         run: |
-          npm version prerelease --preid alpha -m "chore: bump version to %s"
+          CURRENT=$(npm view @gitgrove/cli dist-tags.alpha 2>/dev/null || node -p "require('./package.json').version")
+          npm version "$CURRENT" --no-git-tag-version --allow-same-version
+          npm version prerelease --preid alpha --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          git tag "v$VERSION"
 
-      - name: Push version commit and tag
-        run: git push --follow-tags
+      - name: Push tag
+        run: git push --tags
 
       - name: Publish to npm
         run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish alpha
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump prerelease version
+        run: |
+          npm version prerelease --preid alpha -m "chore: bump version to %s"
+
+      - name: Push version commit and tag
+        run: git push --follow-tags
+
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: publish-alpha
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -25,6 +29,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run tests
+        run: npm run test:run
 
       - name: Configure git
         run: |


### PR DESCRIPTION
This pull request updates the prerelease version bumping and tagging process in the GitHub Actions workflow for publishing. The main improvement is a more robust and explicit handling of version calculation and git tagging, ensuring that the correct version is tagged and pushed before publishing.

**Workflow improvements:**

* The "Bump prerelease version" step is renamed to "Bump prerelease version and tag" and now:
  * Fetches the current prerelease version from npm (or falls back to the version in `package.json`).
  * Sets the package version to the current version (if necessary) without creating a git tag.
  * Bumps the prerelease version with the `alpha` preid, again without creating a git tag.
  * Creates a git tag for the new version.
* The "Push version commit and tag" step is replaced with a "Push tag" step that only pushes the new git tag, rather than all tags and commits.