### PR TITLE
Chore/add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -40,7 +41,11 @@ jobs:
 
       - name: Bump prerelease version and tag
         run: |
-          CURRENT=$(npm view @gitgrove/cli dist-tags.alpha 2>/dev/null || node -p "require('./package.json').version")
+          LATEST_TAG=$(git tag -l "v*-alpha*" | sort -V | tail -1)
+          CURRENT=${LATEST_TAG#v}
+          if [ -z "$CURRENT" ]; then
+            CURRENT=$(node -p "require('./package.json').version")
+          fi
           npm version "$CURRENT" --no-git-tag-version --allow-same-version
           npm version prerelease --preid alpha --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump prerelease version
+      - name: Bump prerelease version and tag
         run: |
-          npm version prerelease --preid alpha -m "chore: bump version to %s"
+          CURRENT=$(npm view @gitgrove/cli dist-tags.alpha 2>/dev/null || node -p "require('./package.json').version")
+          npm version "$CURRENT" --no-git-tag-version --allow-same-version
+          npm version prerelease --preid alpha --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          git tag "v$VERSION"
 
-      - name: Push version commit and tag
-        run: git push --follow-tags
+      - name: Push tag
+        run: git push --tags
 
       - name: Publish to npm
         run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Bump prerelease version and tag
         run: |
-          LATEST_TAG=$(git tag -l "v*-alpha*" | sort -V | tail -1)
+          LATEST_TAG=$(git tag --merged HEAD -l "v*-alpha*" | sort -V | tail -1)
           CURRENT=${LATEST_TAG#v}
           if [ -z "$CURRENT" ]; then
             CURRENT=$(node -p "require('./package.json').version")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish alpha
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump prerelease version
+        run: |
+          npm version prerelease --preid alpha -m "chore: bump version to %s"
+
+      - name: Push version commit and tag
+        run: git push --follow-tags
+
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: publish-alpha
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -25,6 +29,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run tests
+        run: npm run test:run
 
       - name: Configure git
         run: |


### PR DESCRIPTION
This pull request updates the workflow for publishing prerelease versions in `.github/workflows/publish.yml`. The main focus is to improve how the current prerelease version is determined and ensure that the workflow has access to the full git history.

Workflow improvements:

* Set `fetch-depth: 0` in the `actions/checkout` step to ensure the workflow fetches the entire git history, which is necessary for accurate tag discovery.
* Changed the logic for determining the current prerelease version: now, the workflow finds the latest alpha tag in git, extracts its version, and falls back to `package.json` only if no such tag exists. This makes version bumping more reliable and consistent with published tags.